### PR TITLE
Updates to pimotorcontrol to add features for voltage/position feedba…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,258 @@
 # pimotorcontrol
-Raspbery Pi motor control, with pulse-based position feedback.  Great for use with automotive wiper motors and a raspberry pi relay hat
+
+Raspberry Pi motor control with position feedback. Great for use with automotive wiper motors, AC motors with separate directional windings, and a Raspberry Pi relay hat.
 
 # Background
-This was originally written to automate the swinging door on our chicken coop, using a 4-lead automotive windshield wiper motor.
 
-With a Raspberry Pi relay hat controlled by GPIO, two relays are able to change the direction of the motor by swapping the polarity.
+This was originally written to automate the swinging door on a chicken coop, using a 4-lead automotive windshield wiper motor.
 
-Many wiper motors have a built-in park switch.  In the vehicle this is used by a relay or computerized module to cut power to the motor when the wiper is in the park position.  However, this also provides a simple way to count the number of turns of a motor, for basic positional feedback.
+With a Raspberry Pi relay hat controlled by GPIO, two relays are able to change the direction of the motor by swapping the polarity. Many wiper motors have a built-in park switch, which provides a simple way to count motor turns for basic positional feedback.
 
-This code is written in such a way that the desired positions are defined by pulses, so it can use other feedback mechanisms, such as multiple pulses per turn for more precise control - like if a motor is equipped with a hall effect sensor or optical feedback mechanism.
+The codebase has since grown to support analog position feedback via an MCP3008 ADC (for potentiometer-equipped motors), configurable relay wiring modes for AC motors, and a command-line interface flexible enough to drive a variety of motor control use cases.
 
 # Features
-- Out of the box should work with any DC/reversible motor, due to using the relays to change polarity of power to the motor
-- Provides a reasonably flexible but basic command line; or can be imported and used from other code for back to back movements without reinitialization
-- System status/movements are journaled to disk to allow for recovery from power or other interruptions to the system.  This is useful in open-loop systems that cannot self-home
-- Journaling to disk is done with explicit disk synchronization to increase reliability, but without blocking timing of the motor pulse monitoring loop (by using concurrent.futures thread executors)
-- dry-run "fake" mode to allow for testing and observing behavior before engaging GPIO for motor outputs or pulse inputs
 
+- Works with DC reversible motors (relay polarity swap) and AC motors with separate forward/reverse leads (enable + direction relay wiring)
+- Two position feedback mechanisms: pulse counting (park switch, hall effect, optical) or analog voltage via MCP3008 ADC (potentiometer)
+- Incremental voltage-based positioning: move a configurable voltage delta per step, with fully-open and fully-closed voltage limits
+- Position reported as both raw voltage and percentage open, with tolerance-aware clamping at limits
+- Configurable relay wiring mode at instantiation — no hardware-specific code changes required
+- Configurable GPIO pin numbers at instantiation — supports non-default relay hat pin assignments
+- Journal file tracks system state across power cycles and process restarts, enabling recovery from interrupted operations
+- Journal writes use explicit disk sync without blocking the motor feedback loop (via `concurrent.futures`)
+- Dry-run `fake` mode for testing behavior without engaging GPIO
+- Flexible command-line interface covering all motor control modes
+- Designed to be imported and used from other code, with all hardware-specific parameters passed at instantiation
 
-# Assumptions
- - The motor direction can be controlled by swapping two relays between their NC and NO positions (with Off being achieved by putting both relays in their NC positions)
- - A basic circuit is provided between the Pi and the feedback mechanism providing the pulses in on a 3.3v GPIO pin
+# Hardware support
 
-# Examples
+## Relay wiring modes
 
-Go from open to close position by watching for 3 pulses. Resume any partial operation that was interrupted on the last run.  In this case the system (according to the state/journal file) was already in the closed position.
+Two relay wiring modes are supported, selected at instantiation via `relay_mode`:
 
-    flieslikeabrick@coop:~ $ python3 motorcontrol.py  --resume --close-pulses=3 close
-    INFO:root:Resume requested but there is no action to resume, current status: closed
-    INFO:root:Closing....
-    Journal says status is closed, not closing
-    flieslikeabrick@coop:~ $ 
+**`independent` (default)** — original behavior. CH1 and CH2 each connect one motor lead to a supply rail. The motor is stopped by setting both leads to the same potential. Suitable for DC motors such as automotive wiper motors.
 
-Go from the closed to open position by watching for the default number of pulses.  However, do this in dry-run mode (will not read or write from GPIO)
+**`enable_direction`** — for motors with a shared neutral/common wire and two separate directional leads, such as single-phase AC motors with separate forward and reverse windings. CH1 is the neutral enable relay; CH2 is the direction selector relay. The neutral relay is always dropped before the direction relay changes state, preventing the motor from attempting to reverse under load.
 
-    flieslikeabrick@coop:~ $ python3 motorcontrol.py --fake open
-    [10 second pause here]
-    Opened
-    flieslikeabrick@coop:~ $ 
+## Position feedback mechanisms
 
+### Pulse-based (original)
 
-Go from open to closed, fake/dryrun, with debug messages:
+The motor's park switch or other feedback mechanism drives a GPIO input pin. The code counts transitions from low to high, stopping after a configured number of pulses. Suitable for wiper motors, motors with hall effect sensors, or any mechanism that produces discrete pulses per revolution.
 
-    flieslikeabrick@coop:~ $ python3 motorcontrol.py --fake  --debug --close-pulses=1 close
-    INFO:root:Closing....
-    DEBUG:root:Creating journal future
-    DEBUG:root:Journal written
-    DEBUG:root:Journal future submitted
-    DEBUG:root:Caught timeouterror, cleaned up all we can
-    DEBUG:root:Sync complete
-    DEBUG:root:Pulse seen.  Now 0/1
-    DEBUG:root:Creating journal future
-    DEBUG:root:Journal future submitted
-    DEBUG:root:Journal written
-    DEBUG:root:Sync complete
-    DEBUG:root:Cleaned up future closing 0-1729130580.0544508
-    DEBUG:root:Cleaned up future closing-1729130579.0074098
-    Closed
-    DEBUG:root:Journal written
-    DEBUG:root:Sync complete
-    flieslikeabrick@coop:~ $ 
+### Analog voltage via MCP3008 ADC
 
-Move to the open position, resuming a prior interrupted operation (if applicable), which in this case there was.  That is, the journal file before this command said "opening 4" which meant "opening, waiting for 4 more pulses".  If the interrupted operation was "opening" but the current command was "close", then the system would finish opening and then close normally.
+For motors equipped with a potentiometer, the wiper voltage is read via an MCP3008 8-channel 10-bit ADC over SPI. This enables true analog position feedback: the motor runs until the ADC reading reaches a target voltage, rather than counting pulses.
 
-    flieslikeabrick@coop:~ $ python3 motorcontrol.py --fake  --resume --open-pulses=5 open
-    INFO:root:Resuming interrupted 'open' action...
-    Opened
-    INFO:root:Resume complete.
-    Journal says status is open, not opening
-    flieslikeabrick@coop:~ $
+The MCP3008 connects to the Raspberry Pi's hardware SPI bus:
 
+| MCP3008 pin | Raspberry Pi |
+|---|---|
+| VDD, VREF | 3.3V or 5V (match to your reference voltage) |
+| AGND, DGND | GND |
+| CLK | GPIO 11 (SPI0 SCLK) |
+| DOUT | GPIO 9 (SPI0 MISO) |
+| DIN | GPIO 10 (SPI0 MOSI) |
+| CS | GPIO 8 (SPI0 CE0) |
+
+Enable SPI on the Pi via `raspi-config` or `/boot/config.txt` before use.
+
+# Classes and key concepts
+
+## `MCP3008PositionSensor`
+
+A simple wrapper around `spidev` that reads a single MCP3008 channel and converts the 10-bit result to a voltage using the configured reference voltage.
+
+```python
+sensor = MCP3008PositionSensor(channel=0, vref=3.3)
+voltage = sensor.read()   # returns float in volts
+sensor.close()
+```
+
+Any object with a `.read()` method returning a float voltage can be substituted, making it straightforward to mock for testing.
+
+## `pimc`
+
+The main motor controller class. Instantiate with your hardware parameters and call action methods or use the CLI.
+
+```python
+from pimotorcontrol import MCP3008PositionSensor, pimc
+
+sensor = MCP3008PositionSensor(channel=0, vref=3.3)
+
+motor = pimc(
+    journal_filename="pimc_status",
+    relay_mode="enable_direction",
+    ch1_pin=21,
+    ch2_pin=20,
+    position_sensor=sensor,
+    voltage_fully_closed=1.2,
+    voltage_fully_open=3.8,
+    voltage_increment=0.4,
+    voltage_tolerance=0.1,
+    maxtime=5,
+)
+```
+
+### Pulse-based operation
+
+Pass `open_pulses` and `close_pulses` at instantiation. Use `open()` and `close()` methods or the corresponding CLI actions.
+
+### Analog voltage operation
+
+Pass a `position_sensor`, `voltage_fully_closed`, `voltage_fully_open`, and `voltage_increment`. Use `open_increment()`, `close_increment()`, or the voltage-based CLI actions.
+
+The `voltage_fully_closed` and `voltage_fully_open` values define the physical travel range. `voltage_increment` is how far to move per step. `voltage_tolerance` is the acceptable margin for declaring a target reached — important for aging potentiometers and real-world mechanical systems that cannot reach an exact voltage repeatably.
+
+### Position percentage
+
+`voltage_to_pct(voltage, voltage_fully_closed, voltage_fully_open, voltage_tolerance=0.0)` is a module-level helper that converts a voltage reading to a percentage open (0.0–100.0), clamped at the limits. When `voltage_tolerance` is provided, readings within tolerance of either limit are reported as exactly 0% or 100%, consistent with the at-limit decisions made by `is_fully_open()` and `is_fully_closed()`.
+
+```python
+from pimotorcontrol import voltage_to_pct
+
+pct = voltage_to_pct(2.4, voltage_fully_closed=1.2, voltage_fully_open=3.8, voltage_tolerance=0.1)
+```
+
+`pimc` also provides `read_position_pct()` as a convenience method for callers that want the percentage without needing a cached voltage reading.
+
+### Direction fault detection
+
+When using analog position feedback, the motor is monitored while running. After a configurable settling period (`direction_settle_seconds`), if the voltage moves more than `direction_fault_threshold` volts in the wrong direction, the motor is stopped and a fault is reported. This catches wiring errors, relay failures, and mechanical issues early.
+
+`direction_fault_threshold` must be greater than `voltage_tolerance`. If it is not, normal ADC noise near the target voltage could trigger false faults. A warning is logged at instantiation if this condition is violated.
+
+### Journaling and recovery
+
+System state is written to a journal file after each operation. On startup with `resume=True`, any interrupted operation is completed before proceeding. This is useful in systems that cannot self-home after a power interruption.
+
+# Command-line interface
+
+`pimotorcontrol.py` can be run directly as a command-line motor controller. `--relay-mode` is required (no default is assumed, as an incorrect value can have physical consequences depending on wiring).
+
+```
+python3 pimotorcontrol.py --relay-mode <mode> <action> [options]
+```
+
+## Actions
+
+| Action | Description | Key arguments |
+|---|---|---|
+| `open-pulses` | Open by pulse count | `--open-pulses` |
+| `close-pulses` | Close by pulse count | `--close-pulses` |
+| `open-seconds` | Open by timed run | `--open-seconds` |
+| `close-seconds` | Close by timed run | `--close-seconds` |
+| `open-voltage` | Open by voltage delta from current position | `--open-voltage`, `--vref` |
+| `close-voltage` | Close by voltage delta from current position | `--close-voltage`, `--vref` |
+| `fully-open-voltage` | Drive to fully open voltage position | `--fully-open-voltage`, `--vref` |
+| `fully-close-voltage` | Drive to fully closed voltage position | `--fully-closed-voltage`, `--vref` |
+| `status` | Print current journal status | |
+
+## Key options
+
+| Option | Description | Default |
+|---|---|---|
+| `--relay-mode` | `independent` or `enable_direction` | **required** |
+| `--vref` | ADC reference voltage (required for voltage actions) | none |
+| `--fully-open-voltage` | Voltage at fully open position | none |
+| `--fully-closed-voltage` | Voltage at fully closed position | none |
+| `--open-voltage` | Positive voltage delta for open-voltage action | none |
+| `--close-voltage` | Positive voltage delta for close-voltage action | none |
+| `--voltage-tolerance` | Acceptable margin for reaching a target voltage | 0.1V |
+| `--direction-fault-threshold` | Wrong-direction movement that triggers a fault | 0.1V |
+| `--direction-settle` | Seconds before direction checking begins | 0.1s |
+| `--poll-interval` | Seconds between ADC reads | 0.05s |
+| `--open-pulses` | Pulse count for open operation | 11 |
+| `--close-pulses` | Pulse count for close operation | 11 |
+| `--open-seconds` | Seconds to run for open operation | none |
+| `--close-seconds` | Seconds to run for close operation | none |
+| `--max-time` | Maximum motor runtime per operation | 30s |
+| `--ch1-pin` | BCM GPIO pin for relay channel 1 | 26 |
+| `--ch2-pin` | BCM GPIO pin for relay channel 2 | 20 |
+| `--journal-filename` | Path to journal file | `pimc_status` |
+| `--adc-channel` | MCP3008 input channel | 0 |
+| `--resume` | Resume any prior interrupted operation | off |
+| `--fake` | Dry-run mode, no GPIO interaction | off |
+| `--debug` | Verbose debug logging | off |
+
+Note: `--open-voltage` and `--close-voltage` always take a positive absolute value. The direction of movement is implied by the action — the code subtracts the delta internally for close operations.
+
+## CLI examples
+
+Read current ADC voltage (useful for measuring fully-open and fully-closed positions):
+
+```
+python3 -c "from pimotorcontrol import MCP3008PositionSensor; s = MCP3008PositionSensor(vref=3.3); print(s.read())"
+```
+
+Drive to fully open position using ADC feedback:
+
+```
+python3 pimotorcontrol.py \
+  --relay-mode enable_direction \
+  --vref 3.3 \
+  --fully-open-voltage 3.8 \
+  --fully-closed-voltage 1.2 \
+  --voltage-tolerance 0.1 \
+  --ch1-pin 21 --ch2-pin 20 \
+  fully-open-voltage
+```
+
+Open by a voltage increment from current position:
+
+```
+python3 pimotorcontrol.py \
+  --relay-mode enable_direction \
+  --vref 3.3 \
+  --fully-open-voltage 3.8 \
+  --fully-closed-voltage 1.2 \
+  --open-voltage 0.4 \
+  --ch1-pin 21 --ch2-pin 20 \
+  open-voltage
+```
+
+Open by pulse count, dry-run mode:
+
+```
+python3 pimotorcontrol.py --relay-mode independent --fake --open-pulses 5 open-pulses
+```
+
+Open by timed run (useful for AC motors without position feedback during initial testing):
+
+```
+python3 pimotorcontrol.py --relay-mode enable_direction --ch1-pin 21 --ch2-pin 20 --open-seconds 2 open-seconds
+```
+
+Resume any interrupted operation, then close:
+
+```
+python3 pimotorcontrol.py --relay-mode independent --resume --close-pulses 3 close-pulses
+```
+
+# Design notes
+
+## Tolerance and direction fault threshold interaction
+
+`voltage_tolerance` and `direction_fault_threshold` interact in a subtle but important way. If `direction_fault_threshold` is less than or equal to `voltage_tolerance`, ADC noise near the target voltage (which is within tolerance and should trigger success) could trigger a direction fault before the success check runs. A warning is logged at instantiation if this condition is detected. Setting `direction_fault_threshold` somewhat larger than `voltage_tolerance` is recommended.
+
+## Settling period
+
+After the motor starts, a short settling period (`direction_settle_seconds`) passes before direction fault checking begins. This accounts for relay contact bounce, motor startup lag, and initial ADC noise. The settling period should be greater than `poll_interval_seconds` so that at least one ADC sample is taken during settling before fault checking starts.
+
+## Journal file
+
+The journal file records the current system state as a plain text string: `open`, `closed`, `opening N` (N pulses remaining), `closing N`, or `failed opening`/`failed closing`. It is synced to disk explicitly after each write to reduce the risk of data loss on power interruption.
+
+# Dependencies
+
+- `RPi.GPIO` — GPIO control
+- `spidev` — SPI communication with MCP3008 (required for analog position feedback only)
+
+Both are typically available on Raspberry Pi OS. SPI must be enabled via `raspi-config` or `/boot/config.txt` for MCP3008 use.
 
 # Possible future work
- - Continue generalizing some hard-coded behaviors
- - Add feedback mechanisms such as limit switches for fully-open or fully-closed positions
- - Possibly generalize "positions" by their "pulse" location, instead of just a hard-coded logical "open" and "close".  This can already be achieved to some degree by using the per-command --open-pulses and --close-pulses arguments
- - Basic Flask interface
+
+- Unified abstraction for move completion feedback (pulse-based and voltage-based share a common structure that could be generalized)
+- Interrupt-driven position feedback for momentary switches (versus polling)
+- Configuration file support for persistent hardware parameters
+- Additional position feedback mechanisms (limit switches as sentinel voltage values via the existing `position_sensor` interface)

--- a/greenhouse.py
+++ b/greenhouse.py
@@ -1,0 +1,469 @@
+import json
+import logging
+import os
+import sys
+import time
+
+from pimotorcontrol import MCP3008PositionSensor, pimc
+from ds18b20 import ds18b20
+
+# -----------------------------------------------------------------------------
+# greenhouse.py - Greenhouse vent temperature controller
+# -----------------------------------------------------------------------------
+#
+# This module provides GreenhouseVentController, which uses a pimc motor
+# controller instance to incrementally open or close greenhouse vents based
+# on temperature readings, with a configurable deadband.
+#
+# INTENDED USAGE (cronjob):
+#
+#   This controller is designed to be invoked by cron on a regular interval
+#   (e.g. every 5 minutes). Each invocation performs exactly one
+#   sample-and-respond cycle, then exits. There is no daemon loop here.
+#
+#   Example crontab entry (runs every 5 minutes):
+#     */5 * * * * /usr/bin/python3 /home/pi/greenhouse.py >> /var/log/greenhouse.log 2>&1
+#
+# FAULT SAFETY AND JOURNAL FILE:
+#
+#   If an unexpected condition occurs (motor fault, ADC read failure, etc.),
+#   the controller writes a fault state to its own journal file and exits
+#   with a non-zero status code. Subsequent cron invocations will read this
+#   fault state, log an error, and exit immediately without touching the motor.
+#
+#   This is intentional. When something unexpected happens to hardware with
+#   real-world consequences, the safest behavior is to stop acting and wait
+#   for a human to investigate and clear the fault manually.
+#
+#   To recover from a fault: inspect the journal file (default:
+#   greenhouse_status.json), address the root cause, then delete or reset
+#   the file. The controller will resume normal operation on the next
+#   cron invocation.
+#
+# TEMPERATURE FUNCTION:
+#
+#   The controller does not contain any temperature-reading logic. Instead,
+#   a callable is passed at instantiation. This callable takes no arguments
+#   and returns a float temperature in Fahrenheit. This decouples the
+#   controller from any specific sensor library or hardware, and makes it
+#   straightforward to test with a mock function.
+#
+#   Example using an existing DS18B20 read function:
+#     from my_sensor_module import read_temperature_f
+#     controller = GreenhouseVentController(motor=mc, get_temperature=read_temperature_f)
+#
+# DEADBAND:
+#
+#   The controller uses a simple deadband to avoid hunting (rapidly
+#   opening and closing in response to small temperature fluctuations):
+#
+#     temperature >= temp_open  => open one increment (unless fully open)
+#     temperature <= temp_close => close one increment (unless fully closed)
+#     temp_close < temperature < temp_open => do nothing
+#
+#   The gap between temp_close and temp_open is the deadband. Default is
+#   70F (close) to 80F (open), giving a 10F deadband.
+# -----------------------------------------------------------------------------
+
+
+class GreenhouseVentController:
+
+    def __init__(self, motor, get_temperature,
+                 temp_open=80.0,
+                 temp_close=70.0,
+                 journal_file="greenhouse_status.json",
+                 logger=None):
+        """Initialize the GreenhouseVentController.
+
+        Args:
+            motor(pimc): An initialized pimc instance with a position_sensor
+                         configured. The motor's voltage limits and increment
+                         are set on the pimc instance, not here.
+            get_temperature(callable): A callable that takes no arguments and
+                                       returns the current temperature as a
+                                       float in Fahrenheit. This is intentionally
+                                       injected rather than hard-coded, so that
+                                       any sensor library or mock can be used
+                                       without modifying this class.
+            temp_open(float): Temperature in Fahrenheit at or above which the
+                              vents should be opened one increment. Default 80.0.
+            temp_close(float): Temperature in Fahrenheit at or below which the
+                               vents should be closed one increment. Default 70.0.
+            journal_file(str): Path to this controller's JSON journal file.
+                               Used to persist fault state across cron invocations.
+                               Distinct from pimc's own journal file. Default is
+                               'greenhouse_status.json' in the current directory.
+            logger(obj): Logger to use. Uses root logger if None.
+        """
+        if temp_close >= temp_open:
+            raise ValueError(
+                f"temp_close ({temp_close}F) must be less than temp_open ({temp_open}F) "
+                f"to create a valid deadband. With equal or reversed values, the controller "
+                f"would attempt to open and close simultaneously."
+            )
+
+        if not callable(get_temperature):
+            raise ValueError("get_temperature must be a callable that returns a float temperature in Fahrenheit")
+
+        if not isinstance(motor, pimc):
+            raise ValueError("motor must be a pimc instance")
+
+        if motor.position_sensor is None:
+            raise ValueError(
+                "The provided pimc instance has no position_sensor configured. "
+                "GreenhouseVentController requires voltage-based position feedback. "
+                "Pass an MCP3008PositionSensor (or compatible object) as position_sensor "
+                "when constructing the pimc instance."
+            )
+
+        self.motor = motor
+        self.get_temperature = get_temperature
+        self.temp_open = temp_open
+        self.temp_close = temp_close
+        self.journal_file = journal_file
+        self.logger = logger or logging.getLogger(__name__)
+
+    # -------------------------------------------------------------------------
+    # Journal file format
+    # -------------------------------------------------------------------------
+    # The journal is a small JSON file with the following structure:
+    #
+    # Normal (no fault):
+    #   {
+    #     "status": "ok",
+    #     "last_run": "2024-06-01T14:35:00",
+    #     "last_temp_f": 82.4,
+    #     "last_action": "opened_increment"
+    #   }
+    #
+    # Fault state:
+    #   {
+    #     "status": "fault",
+    #     "fault_time": "2024-06-01T14:35:00",
+    #     "fault_reason": "Motor fault during open_increment"
+    #   }
+    #
+    # The "status" key is the only one checked on startup. All other fields
+    # are informational and intended for human diagnosis.
+    #
+    # If the journal file does not exist, that is treated as a clean first run
+    # (not a fault). This makes initial deployment straightforward — no need
+    # to pre-create the file.
+    # -------------------------------------------------------------------------
+
+    def _read_journal(self):
+        """Read and return the journal file contents as a dict.
+
+        If the file does not exist, returns None (treated as first run, not fault).
+        If the file exists but cannot be parsed, logs an error and returns a
+        synthetic fault dict to prevent motor operation on a corrupt journal.
+
+        Args:
+            None
+
+        Returns:
+            journal(dict or None): Parsed journal contents, or None if file absent.
+        """
+        if not os.path.exists(self.journal_file):
+            self.logger.debug("No journal file found at %s, treating as first run", self.journal_file)
+            return None
+
+        try:
+            with open(self.journal_file, 'r') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            # A corrupt or unreadable journal is treated as a fault condition.
+            # We cannot safely know the prior state, so we refuse to act.
+            self.logger.error(
+                "Failed to read journal file %s: %s. Treating as fault to prevent "
+                "unsafe operation with unknown prior state.", self.journal_file, e
+            )
+            return {"status": "fault", "fault_reason": f"Unreadable journal: {e}"}
+
+    def _write_journal(self, data):
+        """Write a dict to the journal file as JSON, with OS sync for reliability.
+
+        Mirrors the write-and-sync pattern used in pimc for the same reasons:
+        on a Raspberry Pi that may lose power unexpectedly, an unsynced write
+        can leave a corrupt or empty file, which would then trigger the corrupt-
+        journal fault path on the next run.
+
+        Args:
+            data(dict): Data to write to the journal file.
+
+        Returns:
+            None
+        """
+        try:
+            with open(self.journal_file, 'w') as f:
+                json.dump(data, f, indent=2)
+            os.sync()
+        except OSError as e:
+            # Log but do not raise — a failed journal write should not itself
+            # cause a fault that prevents the controller from finishing its
+            # current cycle. The next run may behave unexpectedly without a
+            # journal, but that is preferable to crashing mid-operation.
+            self.logger.error("Failed to write journal file %s: %s", self.journal_file, e)
+
+    def _write_fault(self, reason):
+        """Write a fault state to the journal file and log the condition.
+
+        After this is called, all subsequent cron invocations will read the
+        fault state and exit without touching the motor, until the fault is
+        manually cleared.
+
+        Args:
+            reason(str): Human-readable description of the fault condition.
+
+        Returns:
+            None
+        """
+        fault_time = time.strftime("%Y-%m-%dT%H:%M:%S")
+        self.logger.error("FAULT: %s. Writing fault state to %s. Manual intervention required.", reason, self.journal_file)
+        self._write_journal({
+            "status": "fault",
+            "fault_time": fault_time,
+            "fault_reason": reason,
+        })
+
+    def _write_ok(self, temperature, action):
+        """Write a successful-run state to the journal file.
+
+        Args:
+            temperature(float or None): The temperature reading from this run,
+                                        in Fahrenheit. The same value that drove
+                                        the control decision in check_and_adjust(),
+                                        passed through rather than re-read, so the
+                                        journal accurately reflects what caused the
+                                        action rather than a subsequent reading.
+            action(str): Description of the action taken this run (e.g. 'opened_increment',
+                         'closed_increment', 'no_action_deadband').
+
+        Returns:
+            None
+        """
+        self._write_journal({
+            "status": "ok",
+            "last_run": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "last_temp_f": temperature,
+            "last_action": action,
+        })
+
+    def check_and_adjust(self):
+        """Perform one temperature sample-and-respond cycle.
+
+        This is the core logic method. It:
+          1. Reads the current temperature via get_temperature()
+          2. Evaluates against the deadband thresholds
+          3. Calls open_increment() or close_increment() on the motor if needed
+          4. Returns a tuple of (action, temperature)
+
+        Returning the temperature alongside the action avoids the need for a
+        second sensor read in run() when writing the journal. The temperature
+        in the journal should reflect the value that drove the control decision,
+        not a re-read taken moments later — particularly since re-reading adds
+        no useful information at the cron timescale and introduces an unnecessary
+        second point of failure.
+
+        This method is separated from run() so that it can be called and tested
+        independently without the journal read/write and exit logic that run()
+        adds for cron deployment.
+
+        Args:
+            None
+
+        Returns:
+            (action, temperature)(tuple):
+                action(str): One of 'opened_increment', 'closed_increment',
+                             'no_action_deadband', 'no_action_fully_open',
+                             'no_action_fully_closed', or 'fault'.
+                temperature(float or None): The temperature reading taken this
+                             cycle, in Fahrenheit. None if the read failed.
+        """
+        # Read temperature from the injected callable.
+        try:
+            temperature = self.get_temperature()
+        except Exception as e:
+            self.logger.error("Failed to read temperature: %s", e)
+            return 'fault', None
+
+        self.logger.info("Temperature reading: %.1fF (open threshold: %.1fF, close threshold: %.1fF)",
+                         temperature, self.temp_open, self.temp_close)
+
+        # --- Deadband evaluation ---
+        #
+        # Three zones:
+        #   temperature >= temp_open  : too hot, open an increment if possible
+        #   temperature <= temp_close : too cold, close an increment if possible
+        #   between the two           : within deadband, do nothing
+        #
+        # The deadband prevents hunting — without it, a temperature sitting
+        # near a single threshold would cause the motor to open and close on
+        # every cron run.
+
+        if temperature >= self.temp_open:
+            self.logger.info("Temperature %.1fF >= open threshold %.1fF, attempting to open one increment",
+                             temperature, self.temp_open)
+
+            if self.motor.is_fully_open():
+                self.logger.info("Vents are already fully open, no action taken")
+                return 'no_action_fully_open', temperature
+
+            result = self.motor.open_increment()
+            if not result:
+                self.logger.error("open_increment() returned failure")
+                return 'fault', temperature
+
+            self.logger.info("Opened one increment successfully")
+            return 'opened_increment', temperature
+
+        elif temperature <= self.temp_close:
+            self.logger.info("Temperature %.1fF <= close threshold %.1fF, attempting to close one increment",
+                             temperature, self.temp_close)
+
+            if self.motor.is_fully_closed():
+                self.logger.info("Vents are already fully closed, no action taken")
+                return 'no_action_fully_closed', temperature
+
+            result = self.motor.close_increment()
+            if not result:
+                self.logger.error("close_increment() returned failure")
+                return 'fault', temperature
+
+            self.logger.info("Closed one increment successfully")
+            return 'closed_increment', temperature
+
+        else:
+            # Temperature is within the deadband. This is the expected steady-state
+            # outcome during a well-regulated day — most runs should land here.
+            self.logger.info("Temperature %.1fF is within deadband (%.1fF - %.1fF), no action taken",
+                             temperature, self.temp_close, self.temp_open)
+            return 'no_action_deadband', temperature
+
+    def run(self):
+        """Run one complete cron-invocation cycle.
+
+        This is the intended entry point when running from cron. It:
+          1. Checks the journal for a prior fault state and exits immediately if found
+          2. Calls check_and_adjust() to evaluate temperature and act
+          3. Writes the outcome to the journal (fault or ok)
+          4. Exits with status code 0 on success, 1 on fault
+
+        Faults cause an immediate exit with sys.exit(1), which cron can be
+        configured to alert on (e.g. MAILTO in crontab).
+
+        Args:
+            None
+
+        Returns:
+            None (exits the process)
+        """
+        # --- Check for prior fault state ---
+        #
+        # If a prior run wrote a fault to the journal, we refuse to operate
+        # until the fault is manually cleared. This is a deliberate safety
+        # choice: we do not know what state the physical system is in after
+        # a fault, and taking further automated action could make things worse.
+        #
+        # To clear a fault: investigate the logged reason, address the root
+        # cause, verify the physical vent position is safe, then delete the
+        # journal file or set "status" to "ok" manually.
+        journal = self._read_journal()
+        if journal is not None and journal.get("status") == "fault":
+            self.logger.error(
+                "Prior fault detected in journal %s. Reason: %s. "
+                "Refusing to operate until fault is manually cleared.",
+                self.journal_file,
+                journal.get("fault_reason", "unknown")
+            )
+            sys.exit(1)
+
+        # --- Run the control cycle ---
+        action, temperature = self.check_and_adjust()
+
+        if action == 'fault':
+            # check_and_adjust already logged the specific error.
+            # Write fault to journal so subsequent runs also abort.
+            self._write_fault("check_and_adjust returned fault — see prior log entries for details")
+            sys.exit(1)
+
+        # The temperature passed here is the same value that drove the control
+        # decision — not a re-read. See _write_ok() and check_and_adjust() for
+        # the reasoning.
+        self._write_ok(temperature, action)
+        self.logger.info("Run complete. Action: %s", action)
+        sys.exit(0)
+
+
+# -----------------------------------------------------------------------------
+# Example usage / entry point
+# -----------------------------------------------------------------------------
+#
+# This block shows how to wire up the controller for the greenhouse use case.
+# Adjust pin numbers, voltage thresholds, and temperature thresholds to match
+# your physical installation.
+#
+# To use from cron, either call this file directly (python3 greenhouse.py)
+# or import GreenhouseVentController and construct it from your own script.
+# -----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s: %(message)s"
+    )
+
+    # --- Temperature sensor ---
+    # Replace this placeholder with your actual DS18B20 (or other) read function.
+    # The function must take no arguments and return a float in Fahrenheit.
+    # Example: from my_sensor import read_temp_f
+    def get_temperature():
+        d = ds18b20.DS18B20()
+        return d.get_temperature(unit=2)
+        raise NotImplementedError(
+            "Replace this placeholder with your actual temperature read function. "
+            "It should take no arguments and return a float in Fahrenheit."
+        )
+
+    # --- ADC position sensor ---
+    # MCP3008 channel 0, 5V reference. Adjust channel and vref to match your wiring.
+    sensor = MCP3008PositionSensor(channel=0, vref=3.3)
+
+    # --- Motor controller ---
+    # Adjust voltage thresholds and increment to match your potentiometer's
+    # actual voltage range once you have measured it on your physical system.
+    #
+    # voltage_fully_closed: voltage when vents are physically closed
+    # voltage_fully_open:   voltage when vents are physically fully open
+    # voltage_increment:    how many volts to move per temperature check cycle
+    # voltage_tolerance:    acceptable margin for "close enough" to a target
+    #
+    # All values are in volts. Measure with a multimeter or by reading the ADC
+    # directly:
+    #   python3 -c "from pimotorcontrol import MCP3008PositionSensor; s = MCP3008PositionSensor(); print(s.read())"
+    motor = pimc(
+        journal_filename="pimc_status",
+        position_sensor=sensor,
+        voltage_fully_closed=1.9,   # replace with measured value
+        voltage_fully_open=2.3,     # replace with measured value
+        voltage_increment=0.1,      # replace with desired step size
+        voltage_tolerance=0.05,
+        direction_fault_threshold=0.3,
+        direction_settle_seconds=0.02,
+        maxtime=2,
+        ch1_pin=21,
+        ch2_pin=20,
+        relay_mode="enable_direction"
+    )
+
+    # --- Vent controller ---
+    controller = GreenhouseVentController(
+        motor=motor,
+        get_temperature=get_temperature,
+        temp_open=80.0,
+        temp_close=70.0,
+        journal_file="greenhouse_status.json",
+    )
+
+    controller.run()

--- a/greenhouse.py
+++ b/greenhouse.py
@@ -1,10 +1,11 @@
+import argparse
 import json
 import logging
 import os
 import sys
 import time
 
-from pimotorcontrol import MCP3008PositionSensor, pimc
+from pimotorcontrol import MCP3008PositionSensor, pimc, voltage_to_pct
 from ds18b20 import ds18b20
 
 # -----------------------------------------------------------------------------
@@ -23,6 +24,9 @@ from ds18b20 import ds18b20
 #
 #   Example crontab entry (runs every 5 minutes):
 #     */5 * * * * /usr/bin/python3 /home/pi/greenhouse.py >> /var/log/greenhouse.log 2>&1
+#
+#   For verbose logging during testing:
+#     python3 greenhouse.py --debug
 #
 # FAULT SAFETY AND JOURNAL FILE:
 #
@@ -62,16 +66,63 @@ from ds18b20 import ds18b20
 #     temp_close < temperature < temp_open => do nothing
 #
 #   The gap between temp_close and temp_open is the deadband. Default is
-#   70F (close) to 80F (open), giving a 10F deadband.
+#   75F (close) to 85F (open), giving a 10F deadband.
+#
+# TELEMETRY:
+#
+#   If a TelemetryClient instance is provided at instantiation, the controller
+#   will emit events to Elasticsearch after each control cycle. Telemetry
+#   failures are non-fatal — a failure to emit never faults the controller.
+#   Telemetry is optional; if no client is provided, all emit calls are skipped.
+#
+#   Events are emitted to the pi-events index. All action, result, and
+#   event_type field values are prefixed with 'greenhouse_vent_' to namespace
+#   them within the shared index. This prevents field value collisions with
+#   other sources and makes Kibana queries unambiguous.
+#
+#   Event document fields:
+#     event_type:        'greenhouse_vent_action'
+#     action:            e.g. 'greenhouse_vent_opened_increment'
+#     result:            e.g. 'greenhouse_vent_success', 'greenhouse_vent_fault'
+#     level:             'info', 'warn', or 'error' (un-prefixed, generic severity)
+#     description:       human-readable context, mirrors the log message (un-prefixed,
+#                        free-text field — namespacing adds no value here)
+#     temperature_f:     the temperature reading that drove the decision
+#     position_voltage:  current ADC voltage at time of emit (if readable)
 # -----------------------------------------------------------------------------
 
 
 class GreenhouseVentController:
 
+    # -------------------------------------------------------------------------
+    # Telemetry field value constants
+    # -------------------------------------------------------------------------
+    # All action, result, and event_type values are defined as class constants
+    # so that they are consistent across emit calls and easy to update if the
+    # naming convention changes. The 'greenhouse_vent_' prefix namespaces these
+    # values within the shared pi-events index.
+    #
+    # level values ('info', 'warn', 'error') and description are intentionally
+    # un-prefixed: level is a generic cross-source severity field (analogous to
+    # a log level) whose value as a common field depends on consistency across
+    # all sources; description is free-text and namespacing adds no value.
+    # -------------------------------------------------------------------------
+    EVENT_TYPE = "greenhouse_vent_action"
+
+    ACTION_OPENED       = "greenhouse_vent_opened_increment"
+    ACTION_CLOSED       = "greenhouse_vent_closed_increment"
+    ACTION_NO_ACTION    = "greenhouse_vent_no_action"
+
+    RESULT_SUCCESS      = "greenhouse_vent_success"
+    RESULT_FAULT        = "greenhouse_vent_fault"
+    RESULT_AT_LIMIT     = "greenhouse_vent_at_limit"
+    RESULT_DEADBAND     = "greenhouse_vent_deadband"
+
     def __init__(self, motor, get_temperature,
-                 temp_open=80.0,
-                 temp_close=70.0,
+                 temp_open=85.0,
+                 temp_close=75.0,
                  journal_file="greenhouse_status.json",
+                 telemetry=None,
                  logger=None):
         """Initialize the GreenhouseVentController.
 
@@ -86,13 +137,17 @@ class GreenhouseVentController:
                                        any sensor library or mock can be used
                                        without modifying this class.
             temp_open(float): Temperature in Fahrenheit at or above which the
-                              vents should be opened one increment. Default 80.0.
+                              vents should be opened one increment. Default 85.0.
             temp_close(float): Temperature in Fahrenheit at or below which the
-                               vents should be closed one increment. Default 70.0.
+                               vents should be closed one increment. Default 75.0.
             journal_file(str): Path to this controller's JSON journal file.
                                Used to persist fault state across cron invocations.
                                Distinct from pimc's own journal file. Default is
                                'greenhouse_status.json' in the current directory.
+            telemetry(TelemetryClient or None): Optional TelemetryClient instance
+                               for emitting events to Elasticsearch. If None,
+                               telemetry is disabled and no emit calls are made.
+                               Telemetry failures are always non-fatal regardless.
             logger(obj): Logger to use. Uses root logger if None.
         """
         if temp_close >= temp_open:
@@ -121,6 +176,7 @@ class GreenhouseVentController:
         self.temp_open = temp_open
         self.temp_close = temp_close
         self.journal_file = journal_file
+        self.telemetry = telemetry
         self.logger = logger or logging.getLogger(__name__)
 
     # -------------------------------------------------------------------------
@@ -249,6 +305,83 @@ class GreenhouseVentController:
             "last_action": action,
         })
 
+    def _emit_event(self, action, result, temperature, level="info",
+                    description=None, timestamp=None):
+        """Emit a vent action event to Elasticsearch via the telemetry client.
+
+        Called after each control cycle outcome. Telemetry failures are logged
+        but never raised — a failure to emit must never fault the controller.
+
+        If no telemetry client is configured, this method is a no-op.
+
+        All action, result, and event_type values use the 'greenhouse_vent_'
+        prefix to namespace them within the shared pi-events index. Use the
+        class constants (ACTION_*, RESULT_*, EVENT_TYPE) rather than raw
+        strings to ensure consistency.
+
+        Args:
+            action(str): What was attempted. Use ACTION_* class constants.
+                         e.g. self.ACTION_OPENED, self.ACTION_NO_ACTION
+            result(str): Outcome of the action. Use RESULT_* class constants.
+                         e.g. self.RESULT_SUCCESS, self.RESULT_FAULT
+            temperature(float or None): The temperature reading that drove the
+                         decision, in Fahrenheit.
+            level(str):  Event severity. 'info' for normal actions, 'warn' for
+                         at-limit and deadband no-ops, 'error' for faults.
+                         Un-prefixed — this is a generic cross-source field.
+                         Defaults to 'info'.
+            description(str or None): Human-readable context for the event,
+                         mirroring the log message. Particularly useful for
+                         non-nominal outcomes where the action and result alone
+                         do not explain what happened. Un-prefixed free-text field.
+                         Defaults to None (omitted from document if not provided).
+            timestamp(str or datetime or None): Timestamp for the event. Should
+                         be passed as the moment the decision was made for accurate
+                         Kibana timeline alignment. If None, the telemetry client
+                         generates one at emit time.
+
+        Returns:
+            None
+        """
+        if self.telemetry is None:
+            return
+
+        # Read current position voltage once and reuse for both the voltage
+        # and percentage fields. Avoids two ADC reads returning slightly
+        # different values due to pot wiper noise.
+        position_voltage = None
+        position_pct = None
+        try:
+            position_voltage = self.motor.read_position()
+            position_pct = voltage_to_pct(
+                position_voltage,
+                self.motor.voltage_fully_closed,
+                self.motor.voltage_fully_open
+            )
+        except Exception as e:
+            self.logger.debug("_emit_event: could not read position for telemetry: %s", e)
+
+        document = {
+            "event_type":   self.EVENT_TYPE,
+            "action":       action,
+            "result":       result,
+            "level":        level,
+        }
+
+        if description is not None:
+            document["description"] = description
+
+        if temperature is not None:
+            document["temperature_f"] = temperature
+
+        if position_voltage is not None:
+            document["position_voltage"] = position_voltage
+
+        if position_pct is not None:
+            document["position_pct"] = round(position_pct, 1)
+
+        self.telemetry.emit_event(document, timestamp=timestamp)
+
     def check_and_adjust(self):
         """Perform one temperature sample-and-respond cycle.
 
@@ -256,7 +389,8 @@ class GreenhouseVentController:
           1. Reads the current temperature via get_temperature()
           2. Evaluates against the deadband thresholds
           3. Calls open_increment() or close_increment() on the motor if needed
-          4. Returns a tuple of (action, temperature)
+          4. Emits a telemetry event if a telemetry client is configured
+          5. Returns a tuple of (action, temperature)
 
         Returning the temperature alongside the action avoids the need for a
         second sensor read in run() when writing the journal. The temperature
@@ -285,6 +419,13 @@ class GreenhouseVentController:
             temperature = self.get_temperature()
         except Exception as e:
             self.logger.error("Failed to read temperature: %s", e)
+            self._emit_event(
+                action=self.ACTION_NO_ACTION,
+                result=self.RESULT_FAULT,
+                temperature=None,
+                level="error",
+                description=f"Temperature read failed: {e}",
+            )
             return 'fault', None
 
         self.logger.info("Temperature reading: %.1fF (open threshold: %.1fF, close threshold: %.1fF)",
@@ -306,38 +447,147 @@ class GreenhouseVentController:
                              temperature, self.temp_open)
 
             if self.motor.is_fully_open():
-                self.logger.info("Vents are already fully open, no action taken")
+                # Read position once, reuse for log and telemetry.
+                pos_v = self.motor.read_position()
+                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+                self.logger.info(
+                    "Vents are already fully open (%.3fV, %.1f%% open), no action taken",
+                    pos_v, pos_pct
+                )
+                self._emit_event(
+                    action=self.ACTION_OPENED,
+                    result=self.RESULT_AT_LIMIT,
+                    temperature=temperature,
+                    level="warn",
+                    description="Temperature above open threshold but vents already at fully open position.",
+                )
                 return 'no_action_fully_open', temperature
 
-            result = self.motor.open_increment()
-            if not result:
-                self.logger.error("open_increment() returned failure")
+            # Disable limit check since it was explicitly checked above. A duplicate
+            # check could only pick up on noise and confuse matters.
+            result = self.motor.open_increment(check_limits=False)
+
+            if result is False:
+                self.logger.error("open_increment() returned failure — see pimc logs for motor-level detail")
+                self._emit_event(
+                    action=self.ACTION_OPENED,
+                    result=self.RESULT_FAULT,
+                    temperature=temperature,
+                    level="error",
+                    description="open_increment() returned failure — see pimc logs for motor-level detail.",
+                )
                 return 'fault', temperature
 
-            self.logger.info("Opened one increment successfully")
-            return 'opened_increment', temperature
+            elif result is None:
+                pos_v = self.motor.read_position()
+                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+                self.logger.info(
+                    "open_increment() reported already at limit (%.3fV, %.1f%% open), no movement occurred",
+                    pos_v, pos_pct
+                )
+                self._emit_event(
+                    action=self.ACTION_OPENED,
+                    result=self.RESULT_AT_LIMIT,
+                    temperature=temperature,
+                    level="warn",
+                    description="open_increment() reported already at or within tolerance of fully open position.",
+                )
+                return 'no_action_fully_open', temperature
+
+            else:
+                # pimc's open_increment already logged the final voltage and
+                # percentage via its own post-move log. No duplicate read needed here.
+                self.logger.info("Opened one increment successfully")
+                self._emit_event(
+                    action=self.ACTION_OPENED,
+                    result=self.RESULT_SUCCESS,
+                    temperature=temperature,
+                    level="info",
+                )
+                return 'opened_increment', temperature
 
         elif temperature <= self.temp_close:
             self.logger.info("Temperature %.1fF <= close threshold %.1fF, attempting to close one increment",
                              temperature, self.temp_close)
 
             if self.motor.is_fully_closed():
-                self.logger.info("Vents are already fully closed, no action taken")
+                # Read position once, reuse for log and telemetry.
+                pos_v = self.motor.read_position()
+                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+                self.logger.info(
+                    "Vents are already fully closed (%.3fV, %.1f%% open), no action taken",
+                    pos_v, pos_pct
+                )
+                self._emit_event(
+                    action=self.ACTION_CLOSED,
+                    result=self.RESULT_AT_LIMIT,
+                    temperature=temperature,
+                    level="warn",
+                    description="Temperature below close threshold but vents already at fully closed position.",
+                )
                 return 'no_action_fully_closed', temperature
 
-            result = self.motor.close_increment()
-            if not result:
-                self.logger.error("close_increment() returned failure")
+            # Disable limit check since it was explicitly checked above. A duplicate
+            # check could only pick up on noise and confuse matters.
+            result = self.motor.close_increment(check_limits=False)
+
+            if result is False:
+                self.logger.error("close_increment() returned failure — see pimc logs for motor-level detail")
+                self._emit_event(
+                    action=self.ACTION_CLOSED,
+                    result=self.RESULT_FAULT,
+                    temperature=temperature,
+                    level="error",
+                    description="close_increment() returned failure — see pimc logs for motor-level detail.",
+                )
                 return 'fault', temperature
 
-            self.logger.info("Closed one increment successfully")
-            return 'closed_increment', temperature
+            elif result is None:
+                pos_v = self.motor.read_position()
+                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+                self.logger.info(
+                    "close_increment() reported already at limit (%.3fV, %.1f%% open), no movement occurred",
+                    pos_v, pos_pct
+                )
+                self._emit_event(
+                    action=self.ACTION_CLOSED,
+                    result=self.RESULT_AT_LIMIT,
+                    temperature=temperature,
+                    level="warn",
+                    description="close_increment() reported already at or within tolerance of fully closed position.",
+                )
+                return 'no_action_fully_closed', temperature
+
+            else:
+                # pimc's close_increment already logged the final voltage and
+                # percentage via its own post-move log. No duplicate read needed here.
+                self.logger.info("Closed one increment successfully")
+                self._emit_event(
+                    action=self.ACTION_CLOSED,
+                    result=self.RESULT_SUCCESS,
+                    temperature=temperature,
+                    level="info",
+                )
+                return 'closed_increment', temperature
 
         else:
             # Temperature is within the deadband. This is the expected steady-state
             # outcome during a well-regulated day — most runs should land here.
-            self.logger.info("Temperature %.1fF is within deadband (%.1fF - %.1fF), no action taken",
-                             temperature, self.temp_close, self.temp_open)
+            pos_v = self.motor.read_position()
+            pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+            self.logger.info(
+                "Temperature %.1fF is within deadband (%.1fF - %.1fF), no action taken. "
+                "Current position: %.3fV (%.1f%% open)",
+                temperature, self.temp_close, self.temp_open, pos_v, pos_pct
+            )
+            self._emit_event(
+                action=self.ACTION_NO_ACTION,
+                result=self.RESULT_DEADBAND,
+                temperature=temperature,
+                level="info",
+                description=f"Temperature {temperature:.1f}F is within deadband "
+                            f"({self.temp_close:.1f}F - {self.temp_open:.1f}F).",
+            )
             return 'no_action_deadband', temperature
 
     def run(self):
@@ -396,74 +646,100 @@ class GreenhouseVentController:
 
 
 # -----------------------------------------------------------------------------
-# Example usage / entry point
-# -----------------------------------------------------------------------------
-#
-# This block shows how to wire up the controller for the greenhouse use case.
-# Adjust pin numbers, voltage thresholds, and temperature thresholds to match
-# your physical installation.
-#
-# To use from cron, either call this file directly (python3 greenhouse.py)
-# or import GreenhouseVentController and construct it from your own script.
+# Entry point
 # -----------------------------------------------------------------------------
 
 if __name__ == "__main__":
 
+    parser = argparse.ArgumentParser(
+        description="Greenhouse vent temperature controller.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+examples:
+  python3 greenhouse.py                        # normal cron run
+  python3 greenhouse.py --debug                # verbose logging for testing
+  python3 greenhouse.py --es-host 172.28.11.170 --es-api-key <key>  # with telemetry
+        """
+    )
+
+    parser.add_argument("--debug", action="store_true",
+                        help="Enable verbose debug logging.")
+
+    # --- Telemetry args ---
+    # These are optional. If --es-api-key is not provided, telemetry is disabled
+    # and the controller runs normally without emitting to Elasticsearch.
+    parser.add_argument("--es-host", action="store", default="localhost",
+                        help="Elasticsearch host for telemetry (default: localhost).")
+    parser.add_argument("--es-port", action="store", type=int, default=9200,
+                        help="Elasticsearch port for telemetry (default: 9200).")
+    parser.add_argument("--es-api-key", action="store", default=None,
+                        help="Elasticsearch API key for telemetry. "
+                             "If not provided, telemetry is disabled.")
+
+    args = parser.parse_args()
+
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.DEBUG if args.debug else logging.INFO,
         format="%(asctime)s %(levelname)s: %(message)s"
     )
 
+    logger = logging.getLogger(__name__)
+
+    # --- Telemetry client ---
+    # Only instantiated if --es-api-key is provided. Telemetry is optional —
+    # the controller runs normally without it.
+    telemetry = None
+    if args.es_api_key:
+        from telemetry import TelemetryClient
+        telemetry = TelemetryClient(
+            api_key=args.es_api_key,
+            host=args.es_host,
+            port=args.es_port,
+            source="greenhouse",
+            logger=logger,
+        )
+        logger.info("Telemetry enabled. host=%s port=%s", args.es_host, args.es_port)
+    else:
+        logger.debug("No --es-api-key provided, telemetry disabled.")
+
     # --- Temperature sensor ---
-    # Replace this placeholder with your actual DS18B20 (or other) read function.
-    # The function must take no arguments and return a float in Fahrenheit.
-    # Example: from my_sensor import read_temp_f
     def get_temperature():
         d = ds18b20.DS18B20()
         return d.get_temperature(unit=2)
-        raise NotImplementedError(
-            "Replace this placeholder with your actual temperature read function. "
-            "It should take no arguments and return a float in Fahrenheit."
-        )
 
     # --- ADC position sensor ---
-    # MCP3008 channel 0, 5V reference. Adjust channel and vref to match your wiring.
     sensor = MCP3008PositionSensor(channel=0, vref=3.3)
 
     # --- Motor controller ---
-    # Adjust voltage thresholds and increment to match your potentiometer's
-    # actual voltage range once you have measured it on your physical system.
-    #
-    # voltage_fully_closed: voltage when vents are physically closed
-    # voltage_fully_open:   voltage when vents are physically fully open
-    # voltage_increment:    how many volts to move per temperature check cycle
-    # voltage_tolerance:    acceptable margin for "close enough" to a target
     #
     # All values are in volts. Measure with a multimeter or by reading the ADC
     # directly:
-    #   python3 -c "from pimotorcontrol import MCP3008PositionSensor; s = MCP3008PositionSensor(); print(s.read())"
+    #   python3 -c "from pimotorcontrol import MCP3008PositionSensor; s = MCP3008PositionSensor(vref=3.3); print(s.read())"
     motor = pimc(
         journal_filename="pimc_status",
         position_sensor=sensor,
-        voltage_fully_closed=1.9,   # replace with measured value
-        voltage_fully_open=2.3,     # replace with measured value
-        voltage_increment=0.1,      # replace with desired step size
-        voltage_tolerance=0.05,
+        voltage_fully_closed=1.95,
+        voltage_fully_open=2.3,
+        voltage_increment=0.25,
+        voltage_tolerance=0.1,
         direction_fault_threshold=0.3,
         direction_settle_seconds=0.02,
         maxtime=2,
         ch1_pin=21,
         ch2_pin=20,
-        relay_mode="enable_direction"
+        relay_mode="enable_direction",
+        logger=logger,
     )
 
     # --- Vent controller ---
     controller = GreenhouseVentController(
         motor=motor,
         get_temperature=get_temperature,
-        temp_open=80.0,
-        temp_close=70.0,
+        temp_open=85.0,
+        temp_close=75.0,
         journal_file="greenhouse_status.json",
+        telemetry=telemetry,
+        logger=logger,
     )
 
     controller.run()

--- a/greenhouse.py
+++ b/greenhouse.py
@@ -23,10 +23,17 @@ from ds18b20 import ds18b20
 #   sample-and-respond cycle, then exits. There is no daemon loop here.
 #
 #   Example crontab entry (runs every 5 minutes):
-#     */5 * * * * /usr/bin/python3 /home/pi/greenhouse.py >> /var/log/greenhouse.log 2>&1
+#     */5 * * * * /usr/bin/python3 /home/pi/greenhouse.py --config greenhouse.yaml >> /var/log/greenhouse.log 2>&1
 #
 #   For verbose logging during testing:
-#     python3 greenhouse.py --debug
+#     python3 greenhouse.py --config greenhouse.yaml --debug
+#
+# CONFIGURATION:
+#
+#   All deployment-specific values (voltage thresholds, pin numbers, temperature
+#   thresholds, Elasticsearch credentials) live in greenhouse.yaml. CLI arguments
+#   override config file values when both are provided. Values absent from the
+#   config file fall back to argparse defaults.
 #
 # FAULT SAFETY AND JOURNAL FILE:
 #
@@ -39,57 +46,79 @@ from ds18b20 import ds18b20
 #   real-world consequences, the safest behavior is to stop acting and wait
 #   for a human to investigate and clear the fault manually.
 #
-#   To recover from a fault: inspect the journal file (default:
-#   greenhouse_status.json), address the root cause, then delete or reset
-#   the file. The controller will resume normal operation on the next
-#   cron invocation.
+#   To recover from a fault: inspect the journal file, address the root cause,
+#   then delete the journal file or set "status" to "ok" manually.
 #
 # TEMPERATURE FUNCTION:
 #
 #   The controller does not contain any temperature-reading logic. Instead,
 #   a callable is passed at instantiation. This callable takes no arguments
-#   and returns a float temperature in Fahrenheit. This decouples the
-#   controller from any specific sensor library or hardware, and makes it
-#   straightforward to test with a mock function.
-#
-#   Example using an existing DS18B20 read function:
-#     from my_sensor_module import read_temperature_f
-#     controller = GreenhouseVentController(motor=mc, get_temperature=read_temperature_f)
+#   and returns a float temperature in Fahrenheit.
 #
 # DEADBAND:
 #
-#   The controller uses a simple deadband to avoid hunting (rapidly
-#   opening and closing in response to small temperature fluctuations):
+#   The controller uses a simple deadband to avoid hunting:
 #
 #     temperature >= temp_open  => open one increment (unless fully open)
 #     temperature <= temp_close => close one increment (unless fully closed)
 #     temp_close < temperature < temp_open => do nothing
-#
-#   The gap between temp_close and temp_open is the deadband. Default is
-#   75F (close) to 85F (open), giving a 10F deadband.
 #
 # TELEMETRY:
 #
 #   If a TelemetryClient instance is provided at instantiation, the controller
 #   will emit events to Elasticsearch after each control cycle. Telemetry
 #   failures are non-fatal — a failure to emit never faults the controller.
-#   Telemetry is optional; if no client is provided, all emit calls are skipped.
-#
-#   Events are emitted to the pi-events index. All action, result, and
-#   event_type field values are prefixed with 'greenhouse_vent_' to namespace
-#   them within the shared index. This prevents field value collisions with
-#   other sources and makes Kibana queries unambiguous.
-#
-#   Event document fields:
-#     event_type:        'greenhouse_vent_action'
-#     action:            e.g. 'greenhouse_vent_opened_increment'
-#     result:            e.g. 'greenhouse_vent_success', 'greenhouse_vent_fault'
-#     level:             'info', 'warn', or 'error' (un-prefixed, generic severity)
-#     description:       human-readable context, mirrors the log message (un-prefixed,
-#                        free-text field — namespacing adds no value here)
-#     temperature_f:     the temperature reading that drove the decision
-#     position_voltage:  current ADC voltage at time of emit (if readable)
+#   Provide Elasticsearch credentials in greenhouse.yaml or via CLI args.
 # -----------------------------------------------------------------------------
+
+
+def load_config(config_path):
+    """Load and return a YAML configuration file as a dict.
+
+    If the file does not exist or cannot be parsed, logs an error and returns
+    an empty dict so that all values fall back to argparse defaults.
+
+    Args:
+        config_path(str): Path to the YAML config file.
+
+    Returns:
+        config(dict): Parsed config contents, or empty dict on failure.
+    """
+    try:
+        import yaml
+    except ImportError:
+        logging.error("PyYAML is not installed. Install with: pip install pyyaml --break-system-packages")
+        return {}
+
+    if not os.path.exists(config_path):
+        logging.error("Config file not found: %s", config_path)
+        return {}
+
+    try:
+        with open(config_path, 'r') as f:
+            return yaml.safe_load(f) or {}
+    except Exception as e:
+        logging.error("Failed to parse config file %s: %s", config_path, e)
+        return {}
+
+
+def cfg(config, *keys, default=None):
+    """Safely retrieve a nested value from a config dict.
+
+    Args:
+        config(dict): The config dict returned by load_config().
+        *keys: Sequence of keys to traverse, e.g. cfg(config, 'motor', 'vref').
+        default: Value to return if any key is missing. Defaults to None.
+
+    Returns:
+        value: The config value, or default if not found.
+    """
+    val = config
+    for key in keys:
+        if not isinstance(val, dict) or key not in val:
+            return default
+        val = val[key]
+    return val
 
 
 class GreenhouseVentController:
@@ -97,15 +126,9 @@ class GreenhouseVentController:
     # -------------------------------------------------------------------------
     # Telemetry field value constants
     # -------------------------------------------------------------------------
-    # All action, result, and event_type values are defined as class constants
-    # so that they are consistent across emit calls and easy to update if the
-    # naming convention changes. The 'greenhouse_vent_' prefix namespaces these
-    # values within the shared pi-events index.
-    #
-    # level values ('info', 'warn', 'error') and description are intentionally
-    # un-prefixed: level is a generic cross-source severity field (analogous to
-    # a log level) whose value as a common field depends on consistency across
-    # all sources; description is free-text and namespacing adds no value.
+    # All action, result, and event_type values are prefixed with
+    # 'greenhouse_vent_' to namespace them within the shared pi-events index.
+    # level values and description are intentionally un-prefixed.
     # -------------------------------------------------------------------------
     EVENT_TYPE = "greenhouse_vent_action"
 
@@ -127,34 +150,19 @@ class GreenhouseVentController:
         """Initialize the GreenhouseVentController.
 
         Args:
-            motor(pimc): An initialized pimc instance with a position_sensor
-                         configured. The motor's voltage limits and increment
-                         are set on the pimc instance, not here.
-            get_temperature(callable): A callable that takes no arguments and
-                                       returns the current temperature as a
-                                       float in Fahrenheit. This is intentionally
-                                       injected rather than hard-coded, so that
-                                       any sensor library or mock can be used
-                                       without modifying this class.
-            temp_open(float): Temperature in Fahrenheit at or above which the
-                              vents should be opened one increment. Default 85.0.
-            temp_close(float): Temperature in Fahrenheit at or below which the
-                               vents should be closed one increment. Default 75.0.
-            journal_file(str): Path to this controller's JSON journal file.
-                               Used to persist fault state across cron invocations.
-                               Distinct from pimc's own journal file. Default is
-                               'greenhouse_status.json' in the current directory.
-            telemetry(TelemetryClient or None): Optional TelemetryClient instance
-                               for emitting events to Elasticsearch. If None,
-                               telemetry is disabled and no emit calls are made.
-                               Telemetry failures are always non-fatal regardless.
+            motor(pimc): An initialized pimc instance with a position_sensor configured.
+            get_temperature(callable): A callable that takes no arguments and returns
+                                       the current temperature as a float in Fahrenheit.
+            temp_open(float): Temperature at or above which vents open one increment. Default 85.0F.
+            temp_close(float): Temperature at or below which vents close one increment. Default 75.0F.
+            journal_file(str): Path to this controller's JSON journal file. Default 'greenhouse_status.json'.
+            telemetry(TelemetryClient or None): Optional TelemetryClient for Elasticsearch. Default None.
             logger(obj): Logger to use. Uses root logger if None.
         """
         if temp_close >= temp_open:
             raise ValueError(
                 f"temp_close ({temp_close}F) must be less than temp_open ({temp_open}F) "
-                f"to create a valid deadband. With equal or reversed values, the controller "
-                f"would attempt to open and close simultaneously."
+                f"to create a valid deadband."
             )
 
         if not callable(get_temperature):
@@ -166,9 +174,7 @@ class GreenhouseVentController:
         if motor.position_sensor is None:
             raise ValueError(
                 "The provided pimc instance has no position_sensor configured. "
-                "GreenhouseVentController requires voltage-based position feedback. "
-                "Pass an MCP3008PositionSensor (or compatible object) as position_sensor "
-                "when constructing the pimc instance."
+                "GreenhouseVentController requires voltage-based position feedback."
             )
 
         self.motor = motor
@@ -182,37 +188,17 @@ class GreenhouseVentController:
     # -------------------------------------------------------------------------
     # Journal file format
     # -------------------------------------------------------------------------
-    # The journal is a small JSON file with the following structure:
-    #
     # Normal (no fault):
-    #   {
-    #     "status": "ok",
-    #     "last_run": "2024-06-01T14:35:00",
-    #     "last_temp_f": 82.4,
-    #     "last_action": "opened_increment"
-    #   }
+    #   { "status": "ok", "last_run": "...", "last_temp_f": 82.4, "last_action": "opened_increment" }
     #
     # Fault state:
-    #   {
-    #     "status": "fault",
-    #     "fault_time": "2024-06-01T14:35:00",
-    #     "fault_reason": "Motor fault during open_increment"
-    #   }
+    #   { "status": "fault", "fault_time": "...", "fault_reason": "..." }
     #
-    # The "status" key is the only one checked on startup. All other fields
-    # are informational and intended for human diagnosis.
-    #
-    # If the journal file does not exist, that is treated as a clean first run
-    # (not a fault). This makes initial deployment straightforward — no need
-    # to pre-create the file.
+    # If the journal file does not exist, that is treated as a clean first run.
     # -------------------------------------------------------------------------
 
     def _read_journal(self):
         """Read and return the journal file contents as a dict.
-
-        If the file does not exist, returns None (treated as first run, not fault).
-        If the file exists but cannot be parsed, logs an error and returns a
-        synthetic fault dict to prevent motor operation on a corrupt journal.
 
         Args:
             None
@@ -228,8 +214,6 @@ class GreenhouseVentController:
             with open(self.journal_file, 'r') as f:
                 return json.load(f)
         except (json.JSONDecodeError, OSError) as e:
-            # A corrupt or unreadable journal is treated as a fault condition.
-            # We cannot safely know the prior state, so we refuse to act.
             self.logger.error(
                 "Failed to read journal file %s: %s. Treating as fault to prevent "
                 "unsafe operation with unknown prior state.", self.journal_file, e
@@ -238,11 +222,6 @@ class GreenhouseVentController:
 
     def _write_journal(self, data):
         """Write a dict to the journal file as JSON, with OS sync for reliability.
-
-        Mirrors the write-and-sync pattern used in pimc for the same reasons:
-        on a Raspberry Pi that may lose power unexpectedly, an unsynced write
-        can leave a corrupt or empty file, which would then trigger the corrupt-
-        journal fault path on the next run.
 
         Args:
             data(dict): Data to write to the journal file.
@@ -255,18 +234,10 @@ class GreenhouseVentController:
                 json.dump(data, f, indent=2)
             os.sync()
         except OSError as e:
-            # Log but do not raise — a failed journal write should not itself
-            # cause a fault that prevents the controller from finishing its
-            # current cycle. The next run may behave unexpectedly without a
-            # journal, but that is preferable to crashing mid-operation.
             self.logger.error("Failed to write journal file %s: %s", self.journal_file, e)
 
     def _write_fault(self, reason):
         """Write a fault state to the journal file and log the condition.
-
-        After this is called, all subsequent cron invocations will read the
-        fault state and exit without touching the motor, until the fault is
-        manually cleared.
 
         Args:
             reason(str): Human-readable description of the fault condition.
@@ -286,14 +257,8 @@ class GreenhouseVentController:
         """Write a successful-run state to the journal file.
 
         Args:
-            temperature(float or None): The temperature reading from this run,
-                                        in Fahrenheit. The same value that drove
-                                        the control decision in check_and_adjust(),
-                                        passed through rather than re-read, so the
-                                        journal accurately reflects what caused the
-                                        action rather than a subsequent reading.
-            action(str): Description of the action taken this run (e.g. 'opened_increment',
-                         'closed_increment', 'no_action_deadband').
+            temperature(float or None): Temperature reading from this run, in Fahrenheit.
+            action(str): Description of the action taken this run.
 
         Returns:
             None
@@ -309,36 +274,16 @@ class GreenhouseVentController:
                     description=None, timestamp=None):
         """Emit a vent action event to Elasticsearch via the telemetry client.
 
-        Called after each control cycle outcome. Telemetry failures are logged
-        but never raised — a failure to emit must never fault the controller.
-
-        If no telemetry client is configured, this method is a no-op.
-
-        All action, result, and event_type values use the 'greenhouse_vent_'
-        prefix to namespace them within the shared pi-events index. Use the
-        class constants (ACTION_*, RESULT_*, EVENT_TYPE) rather than raw
-        strings to ensure consistency.
+        No-op if no telemetry client is configured. Failures are logged but
+        never raised — a failure to emit must never fault the controller.
 
         Args:
             action(str): What was attempted. Use ACTION_* class constants.
-                         e.g. self.ACTION_OPENED, self.ACTION_NO_ACTION
             result(str): Outcome of the action. Use RESULT_* class constants.
-                         e.g. self.RESULT_SUCCESS, self.RESULT_FAULT
-            temperature(float or None): The temperature reading that drove the
-                         decision, in Fahrenheit.
-            level(str):  Event severity. 'info' for normal actions, 'warn' for
-                         at-limit and deadband no-ops, 'error' for faults.
-                         Un-prefixed — this is a generic cross-source field.
-                         Defaults to 'info'.
-            description(str or None): Human-readable context for the event,
-                         mirroring the log message. Particularly useful for
-                         non-nominal outcomes where the action and result alone
-                         do not explain what happened. Un-prefixed free-text field.
-                         Defaults to None (omitted from document if not provided).
-            timestamp(str or datetime or None): Timestamp for the event. Should
-                         be passed as the moment the decision was made for accurate
-                         Kibana timeline alignment. If None, the telemetry client
-                         generates one at emit time.
+            temperature(float or None): Temperature reading that drove the decision.
+            level(str): Event severity: 'info', 'warn', or 'error'. Default 'info'.
+            description(str or None): Human-readable context. Default None.
+            timestamp(str or datetime or None): Event timestamp. Default None (generated at emit time).
 
         Returns:
             None
@@ -346,9 +291,9 @@ class GreenhouseVentController:
         if self.telemetry is None:
             return
 
-        # Read current position voltage once and reuse for both the voltage
-        # and percentage fields. Avoids two ADC reads returning slightly
-        # different values due to pot wiper noise.
+        # Read current position voltage once and reuse for both voltage and
+        # percentage fields, avoiding two ADC reads with potentially differing
+        # values due to pot wiper noise.
         position_voltage = None
         position_pct = None
         try:
@@ -356,7 +301,8 @@ class GreenhouseVentController:
             position_pct = voltage_to_pct(
                 position_voltage,
                 self.motor.voltage_fully_closed,
-                self.motor.voltage_fully_open
+                self.motor.voltage_fully_open,
+                self.motor.voltage_tolerance,
             )
         except Exception as e:
             self.logger.debug("_emit_event: could not read position for telemetry: %s", e)
@@ -385,23 +331,9 @@ class GreenhouseVentController:
     def check_and_adjust(self):
         """Perform one temperature sample-and-respond cycle.
 
-        This is the core logic method. It:
-          1. Reads the current temperature via get_temperature()
-          2. Evaluates against the deadband thresholds
-          3. Calls open_increment() or close_increment() on the motor if needed
-          4. Emits a telemetry event if a telemetry client is configured
-          5. Returns a tuple of (action, temperature)
-
-        Returning the temperature alongside the action avoids the need for a
-        second sensor read in run() when writing the journal. The temperature
-        in the journal should reflect the value that drove the control decision,
-        not a re-read taken moments later — particularly since re-reading adds
-        no useful information at the cron timescale and introduces an unnecessary
-        second point of failure.
-
-        This method is separated from run() so that it can be called and tested
-        independently without the journal read/write and exit logic that run()
-        adds for cron deployment.
+        Reads temperature, evaluates against deadband thresholds, calls
+        open_increment() or close_increment() if needed, emits telemetry,
+        and returns (action, temperature).
 
         Args:
             None
@@ -411,10 +343,9 @@ class GreenhouseVentController:
                 action(str): One of 'opened_increment', 'closed_increment',
                              'no_action_deadband', 'no_action_fully_open',
                              'no_action_fully_closed', or 'fault'.
-                temperature(float or None): The temperature reading taken this
-                             cycle, in Fahrenheit. None if the read failed.
+                temperature(float or None): Temperature reading in Fahrenheit,
+                             or None if the read failed.
         """
-        # Read temperature from the injected callable.
         try:
             temperature = self.get_temperature()
         except Exception as e:
@@ -447,9 +378,8 @@ class GreenhouseVentController:
                              temperature, self.temp_open)
 
             if self.motor.is_fully_open():
-                # Read position once, reuse for log and telemetry.
                 pos_v = self.motor.read_position()
-                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open, self.motor.voltage_tolerance)
                 self.logger.info(
                     "Vents are already fully open (%.3fV, %.1f%% open), no action taken",
                     pos_v, pos_pct
@@ -480,7 +410,7 @@ class GreenhouseVentController:
 
             elif result is None:
                 pos_v = self.motor.read_position()
-                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open, self.motor.voltage_tolerance)
                 self.logger.info(
                     "open_increment() reported already at limit (%.3fV, %.1f%% open), no movement occurred",
                     pos_v, pos_pct
@@ -511,9 +441,8 @@ class GreenhouseVentController:
                              temperature, self.temp_close)
 
             if self.motor.is_fully_closed():
-                # Read position once, reuse for log and telemetry.
                 pos_v = self.motor.read_position()
-                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open, self.motor.voltage_tolerance)
                 self.logger.info(
                     "Vents are already fully closed (%.3fV, %.1f%% open), no action taken",
                     pos_v, pos_pct
@@ -544,7 +473,7 @@ class GreenhouseVentController:
 
             elif result is None:
                 pos_v = self.motor.read_position()
-                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+                pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open, self.motor.voltage_tolerance)
                 self.logger.info(
                     "close_increment() reported already at limit (%.3fV, %.1f%% open), no movement occurred",
                     pos_v, pos_pct
@@ -571,10 +500,8 @@ class GreenhouseVentController:
                 return 'closed_increment', temperature
 
         else:
-            # Temperature is within the deadband. This is the expected steady-state
-            # outcome during a well-regulated day — most runs should land here.
             pos_v = self.motor.read_position()
-            pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open)
+            pos_pct = voltage_to_pct(pos_v, self.motor.voltage_fully_closed, self.motor.voltage_fully_open, self.motor.voltage_tolerance)
             self.logger.info(
                 "Temperature %.1fF is within deadband (%.1fF - %.1fF), no action taken. "
                 "Current position: %.3fV (%.1f%% open)",
@@ -593,14 +520,8 @@ class GreenhouseVentController:
     def run(self):
         """Run one complete cron-invocation cycle.
 
-        This is the intended entry point when running from cron. It:
-          1. Checks the journal for a prior fault state and exits immediately if found
-          2. Calls check_and_adjust() to evaluate temperature and act
-          3. Writes the outcome to the journal (fault or ok)
-          4. Exits with status code 0 on success, 1 on fault
-
-        Faults cause an immediate exit with sys.exit(1), which cron can be
-        configured to alert on (e.g. MAILTO in crontab).
+        Checks for prior fault, calls check_and_adjust(), writes journal,
+        exits with 0 on success or 1 on fault.
 
         Args:
             None
@@ -608,16 +529,6 @@ class GreenhouseVentController:
         Returns:
             None (exits the process)
         """
-        # --- Check for prior fault state ---
-        #
-        # If a prior run wrote a fault to the journal, we refuse to operate
-        # until the fault is manually cleared. This is a deliberate safety
-        # choice: we do not know what state the physical system is in after
-        # a fault, and taking further automated action could make things worse.
-        #
-        # To clear a fault: investigate the logged reason, address the root
-        # cause, verify the physical vent position is safe, then delete the
-        # journal file or set "status" to "ok" manually.
         journal = self._read_journal()
         if journal is not None and journal.get("status") == "fault":
             self.logger.error(
@@ -628,18 +539,12 @@ class GreenhouseVentController:
             )
             sys.exit(1)
 
-        # --- Run the control cycle ---
         action, temperature = self.check_and_adjust()
 
         if action == 'fault':
-            # check_and_adjust already logged the specific error.
-            # Write fault to journal so subsequent runs also abort.
             self._write_fault("check_and_adjust returned fault — see prior log entries for details")
             sys.exit(1)
 
-        # The temperature passed here is the same value that drove the control
-        # decision — not a re-read. See _write_ok() and check_and_adjust() for
-        # the reasoning.
         self._write_ok(temperature, action)
         self.logger.info("Run complete. Action: %s", action)
         sys.exit(0)
@@ -656,25 +561,34 @@ if __name__ == "__main__":
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 examples:
-  python3 greenhouse.py                        # normal cron run
-  python3 greenhouse.py --debug                # verbose logging for testing
-  python3 greenhouse.py --es-host 172.28.11.170 --es-api-key <key>  # with telemetry
+  python3 greenhouse.py --config greenhouse.yaml
+  python3 greenhouse.py --config greenhouse.yaml --debug
+  python3 greenhouse.py --config greenhouse.yaml --temp-open 80 --temp-close 70
         """
     )
 
+    parser.add_argument("--config", action="store", default=None,
+                        help="Path to YAML config file. CLI args override config values.")
     parser.add_argument("--debug", action="store_true",
                         help="Enable verbose debug logging.")
 
     # --- Telemetry args ---
-    # These are optional. If --es-api-key is not provided, telemetry is disabled
-    # and the controller runs normally without emitting to Elasticsearch.
-    parser.add_argument("--es-host", action="store", default="localhost",
-                        help="Elasticsearch host for telemetry (default: localhost).")
-    parser.add_argument("--es-port", action="store", type=int, default=9200,
-                        help="Elasticsearch port for telemetry (default: 9200).")
+    parser.add_argument("--es-host", action="store", default=None,
+                        help="Elasticsearch host. Overrides config file.")
+    parser.add_argument("--es-port", action="store", type=int, default=None,
+                        help="Elasticsearch port. Overrides config file.")
     parser.add_argument("--es-api-key", action="store", default=None,
-                        help="Elasticsearch API key for telemetry. "
-                             "If not provided, telemetry is disabled.")
+                        help="Elasticsearch API key. Overrides config file.")
+
+    # --- Controller args ---
+    parser.add_argument("--temp-open", action="store", type=float, default=None,
+                        help="Temperature threshold to open vents (F). Overrides config.")
+    parser.add_argument("--temp-close", action="store", type=float, default=None,
+                        help="Temperature threshold to close vents (F). Overrides config.")
+    parser.add_argument("--journal-file", action="store", default=None,
+                        help="Path to greenhouse controller journal file. Overrides config.")
+    parser.add_argument("--pimc-journal", action="store", default=None,
+                        help="Path to pimc motor controller journal file. Overrides config.")
 
     args = parser.parse_args()
 
@@ -682,25 +596,75 @@ examples:
         level=logging.DEBUG if args.debug else logging.INFO,
         format="%(asctime)s %(levelname)s: %(message)s"
     )
-
     logger = logging.getLogger(__name__)
 
+    # --- Load config file ---
+    config = {}
+    if args.config:
+        config = load_config(args.config)
+
+    # --- Resolve values: CLI args take precedence over config, config over defaults ---
+    def resolve(cli_val, *config_keys, default=None):
+        """Return CLI value if provided, else config value, else default."""
+        if cli_val is not None:
+            return cli_val
+        config_val = cfg(config, *config_keys)
+        return config_val if config_val is not None else default
+
+    es_host    = resolve(args.es_host,    'elasticsearch', 'host',    default='localhost')
+    es_port    = resolve(args.es_port,    'elasticsearch', 'port',    default=9200)
+    es_api_key = resolve(args.es_api_key, 'elasticsearch', 'api_key', default=None)
+
+    temp_open    = resolve(args.temp_open,    'controller', 'temp_open',    default=85.0)
+    temp_close   = resolve(args.temp_close,   'controller', 'temp_close',   default=75.0)
+    journal_file = resolve(args.journal_file, 'controller', 'journal_file', default='greenhouse_status.json')
+    pimc_journal = resolve(args.pimc_journal, 'controller', 'pimc_journal', default='pimc_status')
+
+    # Motor / ADC values — no CLI overrides for these, config or defaults only.
+    voltage_fully_closed     = cfg(config, 'motor', 'voltage_fully_closed',     default=None)
+    voltage_fully_open       = cfg(config, 'motor', 'voltage_fully_open',       default=None)
+    voltage_increment        = cfg(config, 'motor', 'voltage_increment',        default=None)
+    voltage_tolerance        = cfg(config, 'motor', 'voltage_tolerance',        default=0.1)
+    direction_fault_threshold= cfg(config, 'motor', 'direction_fault_threshold',default=0.1)
+    direction_settle_seconds = cfg(config, 'motor', 'direction_settle_seconds', default=0.1)
+    poll_interval_seconds    = cfg(config, 'motor', 'poll_interval_seconds',    default=0.01)
+    maxtime                  = cfg(config, 'motor', 'maxtime',                  default=30)
+    ch1_pin                  = cfg(config, 'motor', 'ch1_pin',                  default=26)
+    ch2_pin                  = cfg(config, 'motor', 'ch2_pin',                  default=20)
+    relay_mode               = cfg(config, 'motor', 'relay_mode',               default='independent')
+
+    vref        = cfg(config, 'adc', 'vref',    default=None)
+    adc_channel = cfg(config, 'adc', 'channel', default=0)
+
+    # Validate required values that have no safe default.
+    missing = [name for name, val in [
+        ('motor.voltage_fully_closed', voltage_fully_closed),
+        ('motor.voltage_fully_open',   voltage_fully_open),
+        ('motor.voltage_increment',    voltage_increment),
+        ('motor.relay_mode',           relay_mode),
+        ('adc.vref',                   vref),
+    ] if val is None]
+    if missing:
+        logger.error(
+            "The following required values are missing from the config file and "
+            "have no CLI override: %s", ', '.join(missing)
+        )
+        sys.exit(1)
+
     # --- Telemetry client ---
-    # Only instantiated if --es-api-key is provided. Telemetry is optional —
-    # the controller runs normally without it.
     telemetry = None
-    if args.es_api_key:
+    if es_api_key:
         from telemetry import TelemetryClient
         telemetry = TelemetryClient(
-            api_key=args.es_api_key,
-            host=args.es_host,
-            port=args.es_port,
+            api_key=es_api_key,
+            host=es_host,
+            port=es_port,
             source="greenhouse",
             logger=logger,
         )
-        logger.info("Telemetry enabled. host=%s port=%s", args.es_host, args.es_port)
+        logger.info("Telemetry enabled. host=%s port=%s", es_host, es_port)
     else:
-        logger.debug("No --es-api-key provided, telemetry disabled.")
+        logger.debug("No Elasticsearch API key configured, telemetry disabled.")
 
     # --- Temperature sensor ---
     def get_temperature():
@@ -708,26 +672,23 @@ examples:
         return d.get_temperature(unit=2)
 
     # --- ADC position sensor ---
-    sensor = MCP3008PositionSensor(channel=0, vref=3.3)
+    sensor = MCP3008PositionSensor(channel=adc_channel, vref=vref)
 
     # --- Motor controller ---
-    #
-    # All values are in volts. Measure with a multimeter or by reading the ADC
-    # directly:
-    #   python3 -c "from pimotorcontrol import MCP3008PositionSensor; s = MCP3008PositionSensor(vref=3.3); print(s.read())"
     motor = pimc(
-        journal_filename="pimc_status",
+        journal_filename=pimc_journal,
         position_sensor=sensor,
-        voltage_fully_closed=1.95,
-        voltage_fully_open=2.3,
-        voltage_increment=0.25,
-        voltage_tolerance=0.1,
-        direction_fault_threshold=0.3,
-        direction_settle_seconds=0.02,
-        maxtime=2,
-        ch1_pin=21,
-        ch2_pin=20,
-        relay_mode="enable_direction",
+        voltage_fully_closed=voltage_fully_closed,
+        voltage_fully_open=voltage_fully_open,
+        voltage_increment=voltage_increment,
+        voltage_tolerance=voltage_tolerance,
+        direction_fault_threshold=direction_fault_threshold,
+        direction_settle_seconds=direction_settle_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        maxtime=maxtime,
+        ch1_pin=ch1_pin,
+        ch2_pin=ch2_pin,
+        relay_mode=relay_mode,
         logger=logger,
     )
 
@@ -735,9 +696,9 @@ examples:
     controller = GreenhouseVentController(
         motor=motor,
         get_temperature=get_temperature,
-        temp_open=85.0,
-        temp_close=75.0,
-        journal_file="greenhouse_status.json",
+        temp_open=temp_open,
+        temp_close=temp_close,
+        journal_file=journal_file,
         telemetry=telemetry,
         logger=logger,
     )

--- a/greenhouse_metrics.py
+++ b/greenhouse_metrics.py
@@ -1,50 +1,50 @@
 import argparse
 import logging
+import os
 import sys
 
 from pimotorcontrol import MCP3008PositionSensor, voltage_to_pct
 from ds18b20 import ds18b20
 from telemetry import TelemetryClient
+from greenhouse import load_config, cfg
 
 # -----------------------------------------------------------------------------
 # greenhouse_metrics.py - Periodic greenhouse metric telemetry emitter
 # -----------------------------------------------------------------------------
 #
-# This script reads temperature and optionally vent position voltage from the
-# greenhouse Pi and emits them as a metric document to Elasticsearch.
+# Reads temperature and optionally vent position voltage from the greenhouse Pi
+# and emits them as a metric document to Elasticsearch.
 #
-# It is intentionally separate from greenhouse.py (the vent controller) because:
-#   - Metric sampling and vent control run on independent intervals. Temperature
-#     may be sampled every minute for graph resolution while vent control runs
-#     every 5 minutes.
-#   - A telemetry failure should never gate vent control. Keeping them separate
-#     means a failure here has no effect on the vent controller's cron job.
+# Intentionally separate from greenhouse.py because:
+#   - Metric sampling and vent control run on independent intervals.
+#   - A telemetry failure here must never affect the vent controller cron job.
 #
 # INTENDED USAGE (cronjob):
 #
-#   Example crontab entries:
-#     */1 * * * * /usr/bin/python3 /home/pi/greenhouse_metrics.py --es-host 172.28.11.170 --es-api-key <key> >> /var/log/greenhouse_metrics.log 2>&1
-#     */5 * * * * /usr/bin/python3 /home/pi/greenhouse.py --es-host 172.28.11.170 --es-api-key <key> >> /var/log/greenhouse.log 2>&1
+#   */1 * * * * python3 /home/pi/greenhouse_metrics.py --config greenhouse.yaml >> /var/log/greenhouse_metrics.log 2>&1
+#   */5 * * * * python3 /home/pi/greenhouse.py --config greenhouse.yaml >> /var/log/greenhouse.log 2>&1
 #
-# DOCUMENT FORMAT:
+# CONFIGURATION:
 #
-#   Emits to the pi-metrics index with named fields:
-#     {
-#       "@timestamp":      "...",    # time of reading, generated on the Pi
-#       "host":            "pi-greenhouse",
-#       "source":          "greenhouse",
-#       "temperature_f":   82.4,     # always present if sensor is readable
-#       "position_voltage": 2.14     # present only if --vref is provided
-#     }
+#   Shares greenhouse.yaml with greenhouse.py. CLI args override config values.
+#   --es-api-key is required either via config or CLI.
+#   --vref enables ADC position reading; if absent only temperature is emitted.
 #
-#   temperature_f and position_voltage use the same field names as pi-events
-#   documents from greenhouse.py, allowing cross-index Kibana queries on these
-#   fields to return both periodic readings and event-driven readings together.
+# DOCUMENT FORMAT (pi-metrics index):
+#
+#   {
+#     "@timestamp":      "...",
+#     "host":            "pi-greenhouse",
+#     "source":          "greenhouse",
+#     "temperature_f":   82.4,
+#     "position_voltage": 2.14,   # only when --vref / adc.vref is configured
+#     "position_pct":    65.0     # only when voltage limits are also configured
+#   }
 # -----------------------------------------------------------------------------
 
 
 def read_temperature():
-    """Read current temperature from the DS18B20 sensor.
+    """Read current temperature from the DS18B20 sensor in Fahrenheit.
 
     Args:
         None
@@ -58,53 +58,45 @@ def read_temperature():
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Greenhouse metric telemetry emitter. "
-                    "Reads temperature and optionally vent position and emits to Elasticsearch.",
+        description="Greenhouse metric telemetry emitter.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 examples:
-  # temperature only
+  # using config file (recommended)
+  python3 greenhouse_metrics.py --config greenhouse.yaml
+
+  # temperature only, no config file
   python3 greenhouse_metrics.py --es-host 172.28.11.170 --es-api-key <key>
 
-  # temperature and vent position voltage
-  python3 greenhouse_metrics.py --es-host 172.28.11.170 --es-api-key <key> --vref 3.3 --fully-closed-voltage 1.75 --fully-open-voltage 2.3
+  # with position voltage and percentage
+  python3 greenhouse_metrics.py --config greenhouse.yaml --vref 3.3
 
   # verbose logging
-  python3 greenhouse_metrics.py --es-host 172.28.11.170 --es-api-key <key> --debug
+  python3 greenhouse_metrics.py --config greenhouse.yaml --debug
         """
     )
 
+    parser.add_argument("--config", action="store", default=None,
+                        help="Path to YAML config file. CLI args override config values.")
     parser.add_argument("--debug", action="store_true",
                         help="Enable verbose debug logging.")
 
     # --- Telemetry args ---
-    parser.add_argument("--es-host", action="store", default="localhost",
-                        help="Elasticsearch host (default: localhost).")
-    parser.add_argument("--es-port", action="store", type=int, default=9200,
-                        help="Elasticsearch port (default: 9200).")
-    parser.add_argument("--es-api-key", action="store", required=True,
-                        help="Elasticsearch API key. REQUIRED.")
+    parser.add_argument("--es-host", action="store", default=None,
+                        help="Elasticsearch host. Overrides config file.")
+    parser.add_argument("--es-port", action="store", type=int, default=None,
+                        help="Elasticsearch port. Overrides config file.")
+    parser.add_argument("--es-api-key", action="store", default=None,
+                        help="Elasticsearch API key. Overrides config file.")
 
     # --- ADC args ---
-    # --vref is optional. If provided, vent position voltage is read from the
-    # MCP3008 and included in the metric document. If absent, only temperature
-    # is emitted. This allows the script to run even if the ADC is not wired
-    # or available.
+    # --vref enables position voltage reading. If absent, only temperature is emitted.
+    # Voltage limits are read from config to compute position_pct.
     parser.add_argument("--vref", action="store", type=float, default=None,
-                        help="ADC reference voltage in volts. If provided, vent position "
-                             "voltage is read from the MCP3008 and included in the metric "
-                             "document. Must match the MCP3008 VREF pin voltage exactly. "
-                             "If not provided, only temperature is emitted.")
-    parser.add_argument("--adc-channel", action="store", type=int, default=0,
-                        help="MCP3008 analog input channel (default: 0).")
-    parser.add_argument("--fully-closed-voltage", action="store", type=float, default=None,
-                        help="Voltage at the fully closed position, in volts. Required to "
-                             "calculate position_pct alongside position_voltage. "
-                             "Must match the value configured in greenhouse.py.")
-    parser.add_argument("--fully-open-voltage", action="store", type=float, default=None,
-                        help="Voltage at the fully open position, in volts. Required to "
-                             "calculate position_pct alongside position_voltage. "
-                             "Must match the value configured in greenhouse.py.")
+                        help="ADC reference voltage in volts. Overrides config adc.vref. "
+                             "If provided, vent position voltage and percentage are included.")
+    parser.add_argument("--adc-channel", action="store", type=int, default=None,
+                        help="MCP3008 analog input channel. Overrides config adc.channel.")
 
     args = parser.parse_args()
 
@@ -114,22 +106,51 @@ examples:
     )
     logger = logging.getLogger(__name__)
 
+    # --- Load config file ---
+    config = {}
+    if args.config:
+        config = load_config(args.config)
+
+    # --- Resolve values ---
+    def resolve(cli_val, *config_keys, default=None):
+        if cli_val is not None:
+            return cli_val
+        config_val = cfg(config, *config_keys)
+        return config_val if config_val is not None else default
+
+    es_host    = resolve(args.es_host,    'elasticsearch', 'host',    default='localhost')
+    es_port    = resolve(args.es_port,    'elasticsearch', 'port',    default=9200)
+    es_api_key = resolve(args.es_api_key, 'elasticsearch', 'api_key', default=None)
+
+    vref        = resolve(args.vref,        'adc', 'vref',    default=None)
+    adc_channel = resolve(args.adc_channel, 'adc', 'channel', default=0)
+
+    # Voltage limits — needed for position_pct calculation.
+    voltage_fully_closed = cfg(config, 'motor', 'voltage_fully_closed', default=None)
+    voltage_fully_open   = cfg(config, 'motor', 'voltage_fully_open',   default=None)
+    voltage_tolerance    = cfg(config, 'motor', 'voltage_tolerance',    default=0.0)
+
+    # --- Validate required values ---
+    if not es_api_key:
+        logger.error(
+            "Elasticsearch API key is required. Provide via --es-api-key or "
+            "elasticsearch.api_key in the config file."
+        )
+        sys.exit(1)
+
     # --- Telemetry client ---
     telemetry = TelemetryClient(
-        api_key=args.es_api_key,
-        host=args.es_host,
-        port=args.es_port,
+        api_key=es_api_key,
+        host=es_host,
+        port=es_port,
         source="greenhouse",
         logger=logger,
     )
 
     # --- Build metric document ---
-    # Read all sensors first, then emit once. This ensures the document
-    # represents a single point in time as closely as possible, and that
-    # @timestamp (generated by the telemetry client at emit time) reflects
-    # when the readings were taken rather than after any processing.
+    # Read all sensors first, then emit once. This keeps @timestamp as close
+    # as possible to the actual moment of reading.
     document = {}
-    success = True
 
     # Temperature — always attempted.
     try:
@@ -138,32 +159,40 @@ examples:
         logger.info("Temperature: %.1fF", temperature_f)
     except Exception as e:
         logger.error("Failed to read temperature: %s", e)
-        success = False
 
-    # Position voltage — only if --vref was provided.
-    if args.vref is not None:
+    # Position voltage and percentage — only if vref is configured.
+    if vref is not None:
         try:
-            sensor = MCP3008PositionSensor(channel=args.adc_channel, vref=args.vref)
+            sensor = MCP3008PositionSensor(channel=adc_channel, vref=vref)
             position_voltage = sensor.read()
             sensor.close()
             document["position_voltage"] = position_voltage
+
             # Compute percentage from the cached reading rather than re-reading
             # the ADC, to avoid a second read returning a different value due to
-            # pot wiper noise. Requires --fully-closed-voltage and
-            # --fully-open-voltage to be provided.
-            if args.fully_closed_voltage is not None and args.fully_open_voltage is not None:
-                position_pct = voltage_to_pct(position_voltage, args.fully_closed_voltage, args.fully_open_voltage)
+            # pot wiper noise. Requires voltage limits from config.
+            if voltage_fully_closed is not None and voltage_fully_open is not None:
+                position_pct = voltage_to_pct(
+                    position_voltage,
+                    voltage_fully_closed,
+                    voltage_fully_open,
+                    voltage_tolerance,
+                )
                 document["position_pct"] = round(position_pct, 1)
                 logger.info("Position voltage: %.3fV (%.1f%% open)", position_voltage, position_pct)
             else:
-                logger.info("Position voltage: %.3fV (percentage unavailable — provide --fully-closed-voltage and --fully-open-voltage)", position_voltage)
+                logger.info(
+                    "Position voltage: %.3fV (percentage unavailable — "
+                    "motor.voltage_fully_closed and motor.voltage_fully_open "
+                    "must be set in the config file)",
+                    position_voltage
+                )
         except Exception as e:
             logger.error("Failed to read position voltage: %s", e)
             # Not fatal — emit temperature without position if ADC read fails.
 
     # --- Emit ---
     if not document:
-        # Nothing to emit — all reads failed.
         logger.error("No metrics collected, nothing to emit.")
         sys.exit(1)
 

--- a/greenhouse_metrics.py
+++ b/greenhouse_metrics.py
@@ -1,0 +1,181 @@
+import argparse
+import logging
+import sys
+
+from pimotorcontrol import MCP3008PositionSensor, voltage_to_pct
+from ds18b20 import ds18b20
+from telemetry import TelemetryClient
+
+# -----------------------------------------------------------------------------
+# greenhouse_metrics.py - Periodic greenhouse metric telemetry emitter
+# -----------------------------------------------------------------------------
+#
+# This script reads temperature and optionally vent position voltage from the
+# greenhouse Pi and emits them as a metric document to Elasticsearch.
+#
+# It is intentionally separate from greenhouse.py (the vent controller) because:
+#   - Metric sampling and vent control run on independent intervals. Temperature
+#     may be sampled every minute for graph resolution while vent control runs
+#     every 5 minutes.
+#   - A telemetry failure should never gate vent control. Keeping them separate
+#     means a failure here has no effect on the vent controller's cron job.
+#
+# INTENDED USAGE (cronjob):
+#
+#   Example crontab entries:
+#     */1 * * * * /usr/bin/python3 /home/pi/greenhouse_metrics.py --es-host 172.28.11.170 --es-api-key <key> >> /var/log/greenhouse_metrics.log 2>&1
+#     */5 * * * * /usr/bin/python3 /home/pi/greenhouse.py --es-host 172.28.11.170 --es-api-key <key> >> /var/log/greenhouse.log 2>&1
+#
+# DOCUMENT FORMAT:
+#
+#   Emits to the pi-metrics index with named fields:
+#     {
+#       "@timestamp":      "...",    # time of reading, generated on the Pi
+#       "host":            "pi-greenhouse",
+#       "source":          "greenhouse",
+#       "temperature_f":   82.4,     # always present if sensor is readable
+#       "position_voltage": 2.14     # present only if --vref is provided
+#     }
+#
+#   temperature_f and position_voltage use the same field names as pi-events
+#   documents from greenhouse.py, allowing cross-index Kibana queries on these
+#   fields to return both periodic readings and event-driven readings together.
+# -----------------------------------------------------------------------------
+
+
+def read_temperature():
+    """Read current temperature from the DS18B20 sensor.
+
+    Args:
+        None
+
+    Returns:
+        temperature_f(float): Current temperature in Fahrenheit.
+    """
+    d = ds18b20.DS18B20()
+    return d.get_temperature(unit=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Greenhouse metric telemetry emitter. "
+                    "Reads temperature and optionally vent position and emits to Elasticsearch.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+examples:
+  # temperature only
+  python3 greenhouse_metrics.py --es-host 172.28.11.170 --es-api-key <key>
+
+  # temperature and vent position voltage
+  python3 greenhouse_metrics.py --es-host 172.28.11.170 --es-api-key <key> --vref 3.3 --fully-closed-voltage 1.75 --fully-open-voltage 2.3
+
+  # verbose logging
+  python3 greenhouse_metrics.py --es-host 172.28.11.170 --es-api-key <key> --debug
+        """
+    )
+
+    parser.add_argument("--debug", action="store_true",
+                        help="Enable verbose debug logging.")
+
+    # --- Telemetry args ---
+    parser.add_argument("--es-host", action="store", default="localhost",
+                        help="Elasticsearch host (default: localhost).")
+    parser.add_argument("--es-port", action="store", type=int, default=9200,
+                        help="Elasticsearch port (default: 9200).")
+    parser.add_argument("--es-api-key", action="store", required=True,
+                        help="Elasticsearch API key. REQUIRED.")
+
+    # --- ADC args ---
+    # --vref is optional. If provided, vent position voltage is read from the
+    # MCP3008 and included in the metric document. If absent, only temperature
+    # is emitted. This allows the script to run even if the ADC is not wired
+    # or available.
+    parser.add_argument("--vref", action="store", type=float, default=None,
+                        help="ADC reference voltage in volts. If provided, vent position "
+                             "voltage is read from the MCP3008 and included in the metric "
+                             "document. Must match the MCP3008 VREF pin voltage exactly. "
+                             "If not provided, only temperature is emitted.")
+    parser.add_argument("--adc-channel", action="store", type=int, default=0,
+                        help="MCP3008 analog input channel (default: 0).")
+    parser.add_argument("--fully-closed-voltage", action="store", type=float, default=None,
+                        help="Voltage at the fully closed position, in volts. Required to "
+                             "calculate position_pct alongside position_voltage. "
+                             "Must match the value configured in greenhouse.py.")
+    parser.add_argument("--fully-open-voltage", action="store", type=float, default=None,
+                        help="Voltage at the fully open position, in volts. Required to "
+                             "calculate position_pct alongside position_voltage. "
+                             "Must match the value configured in greenhouse.py.")
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(levelname)s: %(message)s"
+    )
+    logger = logging.getLogger(__name__)
+
+    # --- Telemetry client ---
+    telemetry = TelemetryClient(
+        api_key=args.es_api_key,
+        host=args.es_host,
+        port=args.es_port,
+        source="greenhouse",
+        logger=logger,
+    )
+
+    # --- Build metric document ---
+    # Read all sensors first, then emit once. This ensures the document
+    # represents a single point in time as closely as possible, and that
+    # @timestamp (generated by the telemetry client at emit time) reflects
+    # when the readings were taken rather than after any processing.
+    document = {}
+    success = True
+
+    # Temperature — always attempted.
+    try:
+        temperature_f = read_temperature()
+        document["temperature_f"] = temperature_f
+        logger.info("Temperature: %.1fF", temperature_f)
+    except Exception as e:
+        logger.error("Failed to read temperature: %s", e)
+        success = False
+
+    # Position voltage — only if --vref was provided.
+    if args.vref is not None:
+        try:
+            sensor = MCP3008PositionSensor(channel=args.adc_channel, vref=args.vref)
+            position_voltage = sensor.read()
+            sensor.close()
+            document["position_voltage"] = position_voltage
+            # Compute percentage from the cached reading rather than re-reading
+            # the ADC, to avoid a second read returning a different value due to
+            # pot wiper noise. Requires --fully-closed-voltage and
+            # --fully-open-voltage to be provided.
+            if args.fully_closed_voltage is not None and args.fully_open_voltage is not None:
+                position_pct = voltage_to_pct(position_voltage, args.fully_closed_voltage, args.fully_open_voltage)
+                document["position_pct"] = round(position_pct, 1)
+                logger.info("Position voltage: %.3fV (%.1f%% open)", position_voltage, position_pct)
+            else:
+                logger.info("Position voltage: %.3fV (percentage unavailable — provide --fully-closed-voltage and --fully-open-voltage)", position_voltage)
+        except Exception as e:
+            logger.error("Failed to read position voltage: %s", e)
+            # Not fatal — emit temperature without position if ADC read fails.
+
+    # --- Emit ---
+    if not document:
+        # Nothing to emit — all reads failed.
+        logger.error("No metrics collected, nothing to emit.")
+        sys.exit(1)
+
+    result = telemetry.emit_metric(document)
+
+    if not result:
+        logger.error("Failed to emit metric document to Elasticsearch.")
+        sys.exit(1)
+
+    logger.info("Metric emitted successfully.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pimotorcontrol.py
+++ b/pimotorcontrol.py
@@ -662,7 +662,9 @@ class pimc:
         Returns:
             voltage(float): Current position in volts as returned by the sensor.
         """
-        return self.position_sensor.read()
+        voltage = self.position_sensor.read()
+        self.logger.debug("read_position: %.3fV", voltage)
+        return voltage
 
     def read_position_pct(self):
         """Read the current motor position as a percentage open.
@@ -710,7 +712,13 @@ class pimc:
             result(bool): True if current position is within tolerance of fully open
                           or beyond it. """
         current_voltage = current_voltage if current_voltage is not None else self.read_position()
-        return current_voltage >= (self.voltage_fully_open - self.voltage_tolerance)
+        result = current_voltage >= (self.voltage_fully_open - self.voltage_tolerance)
+        self.logger.debug(
+            "is_fully_open: voltage=%.3fV threshold=%.3fV (fully_open=%.3fV - tolerance=%.3fV) => %s",
+            current_voltage, self.voltage_fully_open - self.voltage_tolerance,
+            self.voltage_fully_open, self.voltage_tolerance, result
+        )
+        return result
 
     def is_fully_closed(self, current_voltage=None):
         """Determine whether the motor is at or past the fully closed position.
@@ -725,7 +733,13 @@ class pimc:
                           or beyond it.
         """
         current_voltage = current_voltage if current_voltage is not None else self.read_position()
-        return current_voltage <= (self.voltage_fully_closed + self.voltage_tolerance)
+        result = current_voltage <= (self.voltage_fully_closed + self.voltage_tolerance)
+        self.logger.debug(
+            "is_fully_closed: voltage=%.3fV threshold=%.3fV (fully_closed=%.3fV + tolerance=%.3fV) => %s",
+            current_voltage, self.voltage_fully_closed + self.voltage_tolerance,
+            self.voltage_fully_closed, self.voltage_tolerance, result
+        )
+        return result
 
     def run_until_voltage(self, target_voltage, direction):
         """Run the motor until the ADC reads within tolerance of a target voltage.

--- a/pimotorcontrol.py
+++ b/pimotorcontrol.py
@@ -4,6 +4,7 @@ import logging
 import time
 import os
 import RPi.GPIO as GPIO
+
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
 
@@ -16,21 +17,239 @@ CH2 = 20
 PULSE = 5
 
 # max motor runtime in seconds
+
+
+# -----------------------------------------------------------------------------
+# MCP3008PositionSensor
+# -----------------------------------------------------------------------------
+# This class provides analog position feedback via an MCP3008 ADC chip, which
+# is read over SPI using the Raspberry Pi's hardware SPI interface (spidev).
+#
+# The MCP3008 is an 8-channel, 10-bit ADC. It returns values from 0 to 1023,
+# which this class converts to a real voltage using the configured Vref.
+#
+# Typical wiring for hardware SPI on Raspberry Pi:
+#   MCP3008 VDD  -> 3.3V or 5V (match to Vref)
+#   MCP3008 VREF -> same supply as VDD
+#   MCP3008 AGND -> GND
+#   MCP3008 DGND -> GND
+#   MCP3008 CLK  -> GPIO 11 (SPI0 SCLK)
+#   MCP3008 DOUT -> GPIO 9  (SPI0 MISO)
+#   MCP3008 DIN  -> GPIO 10 (SPI0 MOSI)
+#   MCP3008 CS   -> GPIO 8  (SPI0 CE0)
+#
+# The potentiometer wiper connects to one of the 8 analog input channels
+# (CH0-CH7). The channel is selected in software by the 3-bit address sent
+# during the SPI transaction.
+#
+# Note: SPI chip select (CE0/CE1 on the Pi) is separate from the MCP3008
+# channel selection. Chip select is handled automatically by spidev when
+# you open bus 0, device 0. Channel selection is part of the SPI message
+# payload sent to the MCP3008.
+# -----------------------------------------------------------------------------
+
+class MCP3008PositionSensor:
+
+    def __init__(self, channel=0, vref=5.0):
+        """Initialize an MCP3008 ADC position sensor over hardware SPI.
+
+        Args:
+            channel(int): MCP3008 analog input channel to read (0-7).
+                          Connect the potentiometer wiper to this channel.
+                          Defaults to channel 0.
+            vref(float): Reference voltage supplied to the MCP3008 VREF pin,
+                         in volts. Raw ADC values are scaled against this to
+                         produce a real voltage. Defaults to 5.0V.
+                         Common values are 3.3 or 5.0 depending on your
+                         supply wiring.
+        """
+        if channel < 0 or channel > 7:
+            raise ValueError(f"MCP3008 channel must be 0-7, got {channel}")
+
+        self.channel = channel
+        self.vref = vref
+
+        # Open hardware SPI bus 0, device 0 (CE0).
+        # Requires SPI to be enabled on the Pi (raspi-config or /boot/config.txt).
+        import spidev
+        self.spi = spidev.SpiDev()
+        self.spi.open(0, 0)
+
+        # MCP3008 max SPI clock is 3.6MHz at 5V Vref, or 1.35MHz at 2.7V.
+        # 1MHz is a safe conservative choice that works at both supply voltages.
+        self.spi.max_speed_hz = 1000000
+
+    def read(self):
+        """Read the current voltage from the configured MCP3008 channel.
+
+        Performs a single-ended reading using the standard 3-byte SPI
+        transaction described in the MCP3008 datasheet (section 6.1).
+
+        The 3-byte transaction:
+          Byte 0: 0x01          - start bit
+          Byte 1: (8 + channel) << 4  - single-ended mode + channel select
+          Byte 2: 0x00          - don't care, clocks out the result
+
+        The 10-bit result is reconstructed from bytes 1 and 2 of the response.
+
+        Args:
+            None
+
+        Returns:
+            voltage(float): Measured voltage in volts, scaled to vref.
+        """
+        # Build the 3-byte message for a single-ended read on self.channel.
+        # Byte 1 sets the SGL/DIFF bit (1 = single-ended) and the channel.
+        adc_request = [0x01, (0x08 + self.channel) << 4, 0x00]
+        adc_response = self.spi.xfer2(adc_request)
+
+        # The 10-bit result spans the low 2 bits of response byte 1
+        # and all 8 bits of response byte 2.
+        raw = ((adc_response[1] & 0x03) << 8) | adc_response[2]
+
+        # Convert raw 10-bit value (0-1023) to voltage.
+        # We divide by 1023.0 (not 1024) because 1023 is the maximum
+        # representable value for a 10-bit ADC (2^10 - 1).
+        voltage = (raw / 1023.0) * self.vref
+        return voltage
+
+    def close(self):
+        """Release the SPI device.
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
+        self.spi.close()
+
+
 class pimc:
-    def __init__(self, journal_filename="pimc_status",fake_it=False, open_pulses=11, close_pulses=11, maxtime=30, logger=None, resume=False, open_seconds=10, close_seconds=10):
+
+    # Valid relay_mode values.
+    # 'independent': original behavior. CH1 and CH2 each connect one motor lead
+    #                to either a positive or negative supply. The motor is stopped
+    #                by setting both leads to the same potential. This is the
+    #                original wiper-motor wiring described in pimotorcontrol.
+    # 'enable_direction': alternate wiring for motors where one wire is a shared
+    #                neutral/common and two separate wires select direction (e.g.
+    #                a single-phase AC motor with separate forward and reverse
+    #                windings). CH1 is the enable relay (connects neutral/common
+    #                to the motor). CH2 is the direction selector relay (selects
+    #                which of the two directional leads is energized).
+    #
+    #                IMPORTANT — sequencing in enable_direction mode:
+    #                Neutral (CH1) must always be dropped BEFORE any change to
+    #                the direction relay (CH2). Changing direction while the motor
+    #                is energized causes the motor to attempt to reverse under load,
+    #                which produces mechanical shock and inrush current. The
+    #                stop_and_housekeeping() method enforces this sequencing.
+    #
+    #                The physical mapping of CH2 states to "forward" and "reverse"
+    #                is determined entirely by wiring and is intentionally not
+    #                defined here. forward() sets CH2 LOW and reverse() sets CH2
+    #                HIGH (with CH1 enabled in both cases); which physical direction
+    #                corresponds to which CH2 state is the integrator's decision.
+    RELAY_MODES = ('independent', 'enable_direction')
+
+    def __init__(self, journal_filename="pimc_status", fake_it=False, open_pulses=11, close_pulses=11, maxtime=30, logger=None, resume=False, open_seconds=10, close_seconds=10,
+                 # --- ADC/analog position feedback arguments ---
+                 # These arguments enable voltage-based position feedback via an
+                 # MCP3008 ADC (or any object with a .read() method returning volts).
+                 # If position_sensor is None, the existing pulse-based behavior is
+                 # used unchanged, preserving full backward compatibility.
+                 position_sensor=None,
+                 voltage_fully_open=None,
+                 voltage_fully_closed=None,
+                 voltage_increment=None,
+                 voltage_tolerance=0.1,
+                 direction_fault_threshold=0.1,
+                 direction_settle_seconds=0.1,
+                 poll_interval_seconds=0.01,
+                 ch1_pin=CH1,
+                 ch2_pin=CH2,
+                 relay_mode='independent'):
         """Initialize a new pimc object
+
         Args:
             journal_filename(str): Absolute or relative (to cwd) path to journal file. Must exist and be non-empty with current system state
-            fake_it(bool): If true, all GPIO/motor interactions are emulated for testing.  WARNING: journal/state file will still be updated, ensure it is accurate before real usage
+            fake_it(bool): If true, all GPIO/motor interactions are emulated for testing. WARNING: journal/state file will still be updated, ensure it is accurate before real usage
             open_pulses(int): Number of pulses to detect for transition from closed to open state
             close_pulses(int): Number of pulses to detect for transition from open to closed state
             logger(obj): Logger object to use; will use root logger if none is passed
-            resume(bool): Resume interrupted actions from journal file instead of throwing error"""
+            resume(bool): Resume interrupted actions from journal file instead of throwing error
+            position_sensor(obj): Optional. An object with a .read() method that returns a float
+                                  voltage representing the current motor position. When provided,
+                                  voltage-based position feedback is used instead of pulse counting.
+                                  An MCP3008PositionSensor instance is the intended use, but any
+                                  object implementing .read() -> float will work, which also makes
+                                  this easy to mock for testing.
+            voltage_fully_open(float): Voltage (in volts) representing the fully open position.
+                                       Required if position_sensor is provided. Higher voltage means
+                                       more open. The motor will not be driven past this threshold.
+            voltage_fully_closed(float): Voltage (in volts) representing the fully closed position.
+                                         Required if position_sensor is provided.
+            voltage_increment(float): Optional voltage delta per open/close step, used by
+                                      open_increment() and close_increment(). Not required at
+                                      construction time — only needed if those methods will be
+                                      called. The CLI uses per-action voltage deltas instead and
+                                      does not require this argument.
+            voltage_tolerance(float): Acceptable margin (in volts) when determining whether a target
+                                      voltage has been reached. Defaults to 0.1V. See the comment
+                                      block in run_until_voltage() for important design notes on
+                                      how this interacts with direction_fault_threshold.
+            direction_fault_threshold(float): If the voltage moves this many volts in the wrong
+                                              direction (after the settling period), the motor is
+                                              stopped and a fault is raised. Defaults to 0.1V.
+                                              Must be greater than voltage_tolerance; a warning is
+                                              logged at init time if this is violated. See the
+                                              comment block in run_until_voltage() for details.
+            direction_settle_seconds(float): Seconds to wait after starting the motor before
+                                             checking for wrong-direction movement. Allows for
+                                             motor startup lag and initial ADC noise to settle
+                                             before direction validation begins.
+                                             Defaults to 0.1s (2x the default poll_interval_seconds).
+                                             For applications where each increment moves the motor
+                                             for only 50-200ms total, this should be kept small —
+                                             a settling period that is a large fraction of total
+                                             move time defeats the purpose of direction checking.
+                                             A value of 2x-3x poll_interval_seconds is a reasonable
+                                             starting point.
+            poll_interval_seconds(float): How long to sleep between ADC reads inside the
+                                          run_until_voltage() loop. Controls both CPU usage and
+                                          the responsiveness of position feedback. Defaults to
+                                          0.05s (50ms). For short moves (50-200ms total travel),
+                                          smaller values give more position samples per move.
+                                          Should be smaller than direction_settle_seconds so that
+                                          at least one sample is taken during the settling period
+                                          before direction checking begins.
+            ch1_pin(int): BCM GPIO pin number for relay channel 1. Defaults to 26.
+                          In 'independent' mode: controls motor lead 1.
+                          In 'enable_direction' mode: controls the neutral/enable relay.
+            ch2_pin(int): BCM GPIO pin number for relay channel 2. Defaults to 20.
+                          In 'independent' mode: controls motor lead 2.
+                          In 'enable_direction' mode: controls the direction selector relay.
+            relay_mode(str): Relay wiring and control paradigm. One of:
+                             'independent' (default): original pimotorcontrol behavior.
+                                 CH1 and CH2 each connect one motor lead to a supply rail.
+                                 Motor is stopped by setting both leads to the same potential.
+                             'enable_direction': alternate mode for motors with a shared
+                                 neutral/common and separate directional leads (e.g. single-phase
+                                 AC motors with forward/reverse windings). CH1 enables the neutral;
+                                 CH2 selects direction. Neutral is always dropped before direction
+                                 changes. See class-level comment for full wiring notes.
+                             NOTE: relay_mode defaults to 'independent' in the Python API for
+                             backward compatibility with code that imports pimc directly. When
+                             using the CLI, --relay-mode is mandatory — no default is assumed
+                             there, because an incorrect relay mode can have unintended physical
+                             consequences depending on wiring.
+        """
         self.logger = logger or logging.getLogger(__name__)
         self.journal_filename = journal_filename
         self.gpio_initialized = False
         self.journal_executor = concurrent.futures.ThreadPoolExecutor(max_workers=8)
-        self.journal_futures = {} # dict of future to what they were writing
+        self.journal_futures = {}  # dict of future to what they were writing
         self.motor_busy = False
         self.faking_it = fake_it
         self.open_pulses = open_pulses
@@ -38,52 +257,170 @@ class pimc:
         self.open_seconds = open_seconds
         self.close_seconds = close_seconds
         self.maxtime = maxtime
+
+        # Store configurable pin numbers. Defaulting to the original module-level
+        # constants preserves backward compatibility for existing users.
+        self.ch1_pin = ch1_pin
+        self.ch2_pin = ch2_pin
+
+        # Validate and store relay_mode.
+        if relay_mode not in self.RELAY_MODES:
+            raise ValueError(
+                f"relay_mode must be one of {self.RELAY_MODES}, got '{relay_mode}'"
+            )
+        self.relay_mode = relay_mode
+
+        # --- ADC/analog position feedback setup ---
+        self.position_sensor = position_sensor
+
+        if position_sensor is not None:
+            # voltage_fully_open and voltage_fully_closed are required whenever a
+            # position_sensor is provided, because they define the hard limits used
+            # by is_fully_open(), is_fully_closed(), and run_until_voltage().
+            # Without them, no voltage-based movement can be safely bounded.
+            #
+            # voltage_increment is intentionally NOT required here. It is only
+            # needed by open_increment() and close_increment(), which are used by
+            # GreenhouseVentController and similar callers that move in fixed steps.
+            # The CLI voltage actions compute their own per-call targets from
+            # per-action delta arguments and do not use voltage_increment at all.
+            # Callers that do need open_increment()/close_increment() are responsible
+            # for providing voltage_increment at construction time.
+            missing = [name for name, val in [
+                ("voltage_fully_open", voltage_fully_open),
+                ("voltage_fully_closed", voltage_fully_closed),
+            ] if val is None]
+            if missing:
+                raise ValueError(
+                    f"position_sensor provided but the following required voltage "
+                    f"arguments are missing: {', '.join(missing)}"
+                )
+
+            self.voltage_fully_open = voltage_fully_open
+            self.voltage_fully_closed = voltage_fully_closed
+            self.voltage_increment = voltage_increment  # may be None; checked in open/close_increment
+            self.voltage_tolerance = voltage_tolerance
+            self.direction_fault_threshold = direction_fault_threshold
+            self.direction_settle_seconds = direction_settle_seconds
+            self.poll_interval_seconds = poll_interval_seconds
+
+            # --- Important: tolerance vs. direction_fault_threshold relationship ---
+            #
+            # These two parameters interact in a subtle but important way, and
+            # the warning below exists to catch a misconfiguration that could
+            # cause confusing behavior in the field.
+            #
+            # voltage_tolerance defines how close to the target voltage we consider
+            # "close enough" — success. It exists because aging potentiometers,
+            # mechanical hard stops, and ADC noise mean we can't always reach an
+            # exact voltage target.
+            #
+            # direction_fault_threshold defines how far the voltage must move in
+            # the WRONG direction before we declare a fault and stop the motor.
+            # It exists as a safety check: if we commanded the motor to open
+            # (voltage should increase) but voltage is falling, something is wrong.
+            #
+            # The problem arises when direction_fault_threshold <= voltage_tolerance:
+            #
+            #   Imagine: target = 3.0V, current = 2.95V, tolerance = 0.1V.
+            #   We are already within tolerance (2.95 is within 0.1 of 3.0), so
+            #   run_until_voltage() would declare success immediately — fine.
+            #   But if direction_fault_threshold = 0.05V and the voltage is 2.94V
+            #   (just outside tolerance), normal ADC jitter of 0.05V in the
+            #   wrong direction would trigger a false fault before the motor even
+            #   has a chance to move.
+            #
+            #   In short: if the fault threshold is tighter than the tolerance,
+            #   normal noise near the target voltage looks like a wrong-direction
+            #   fault. This is especially relevant for aging potentiometers in
+            #   humid environments where ADC readings are less stable.
+            #
+            # The direction_settle_seconds delay (below) helps by not checking
+            # direction until the motor has started moving, but the threshold
+            # relationship is the more fundamental constraint.
+            #
+            # We warn rather than raise an error, because there may be edge cases
+            # where a caller knowingly sets these values this way, and a warning
+            # in the log is preferable to a hard failure at startup.
+            if direction_fault_threshold <= voltage_tolerance:
+                self.logger.warning(
+                    "direction_fault_threshold (%.3fV) is <= voltage_tolerance (%.3fV). "
+                    "This can cause false direction-fault events from ADC noise near the "
+                    "target voltage. Consider setting direction_fault_threshold > voltage_tolerance.",
+                    direction_fault_threshold, voltage_tolerance
+                )
+
+            # --- Important: poll_interval_seconds vs. direction_settle_seconds ---
+            #
+            # poll_interval_seconds should be smaller than direction_settle_seconds
+            # so that at least one ADC sample is taken during the settling window.
+            # If poll_interval >= direction_settle_seconds, the settling period is
+            # effectively zero — the first sample after loop start is already past
+            # the settle window. This is not a hard failure — the code will still
+            # work — but it means the settling period provides no benefit and the
+            # parameters are misleadingly configured.
+            if poll_interval_seconds >= direction_settle_seconds:
+                self.logger.warning(
+                    "poll_interval_seconds (%.3fs) is >= direction_settle_seconds (%.3fs). "
+                    "At least one poll interval should fit within the settling period. "
+                    "Consider setting poll_interval_seconds < direction_settle_seconds.",
+                    poll_interval_seconds, direction_settle_seconds
+                )
+
         self.status = self.load_journal()
         if not self.faking_it:
             self.gpio_setup()
+
         if resume and self.status:
-            if self.status.split()[0] in ('open','closed'):
+            if self.status.split()[0] in ('open', 'closed'):
                 self.logger.info("Resume requested but there is no action to resume, current status: %s", self.status)
             elif not self.resume():
-                self.logger.error("Resume failed, manual intervention is needed.  Current status: %s", self.status)
-            else:
-                self.logger
+                self.logger.error("Resume failed, manual intervention is needed. Current status: %s", self.status)
+        else:
+            self.logger
+
     def resume(self):
         """Resume interrupted 'opening' or 'closing' operations from the journal file
+
         Args:
             None
+
         Returns:
-            status(bool): True if opening/closing was successfully resumed.  False if failed or invalid starting state was detected
+            status(bool): True if opening/closing was successfully resumed. False if failed or invalid starting state was detected
         """
         remaining_pulses = None
         # load remaining turns from 'opening' or 'closing' states
         status_split = self.status.split()
-        if status_split[0] in ('opening','closing') and len(status_split) > 1:
+        if status_split[0] in ('opening', 'closing') and len(status_split) > 1:
             try:
                 remaining_pulses = int(status_split[1])
             except ValueError:
                 self.logger.error('Cannot resume, opening/closing status has non-integer pulse count: %s', self.status)
                 return False
+
         if status_split[0] == 'opening':
             self.logger.info("Resuming interrupted 'open' action...")
             self.open(remaining_pulses, resuming=True)
             self.logger.info("Resume complete.")
             return True
+
         if status_split[0] == 'closing':
             self.logger.info("Resuming interrupted 'close' action...")
             self.close(remaining_pulses, resuming=True)
             self.logger.info("Resume complete.")
             return True
+
         else:
             self.logger.error("Cannot resume from status %s", self.status)
             return False
 
-
     def update_status(self, new_status, use_future=True):
         """Update the internal state and journal file to the new value
+
         Args:
             new_status(str): New status such as: open, closed; opening or closing [followed by pulses remaining]; failure (optionally with additional description)
             use_future(bool): Use concurrent.futures for writing the journal file to avoid blocking
+
         Returns:
             None
         """
@@ -95,38 +432,50 @@ class pimc:
             self.logger.debug("Journal future submitted")
         else:
             self.write_journal()
+
     def load_journal(self):
         """Read and test the journal file
+
         Args:
             None
+
         Returns:
             status(str): The system status from the journal file
         """
         if not os.path.exists(self.journal_filename):
             self.logger.critical("Journal file %s does not exist, this must exist to know the current status of the system", self.journal_filename)
             return None
+
         with open(self.journal_filename) as f:
             status = f.read().strip()
+
         if not status:
             self.logger.critical("Journal file %s is empty, this must exist to know the current status of the system", self.journal_filename)
             return None
+
         return status
+
     def write_journal(self):
         """Write status to the journal and force OS sync; blocking; should be called outside loops or threaded.
+
         Args:
             None
+
         Returns:
             None
         """
-        with open(self.journal_filename,'w') as f:
+        with open(self.journal_filename, 'w') as f:
             f.write(self.status)
         self.logger.debug("Journal written")
         os.sync()
         self.logger.debug("Sync complete")
+
     def cleanup_completed_journal_futures(self):
-        """Clean up completed futures  used for journal updates
+        """Clean up completed futures used for journal updates
+
         Args:
             None
+
         Returns:
             None
         """
@@ -137,15 +486,18 @@ class pimc:
                 futures_completed.append(future)
         except TimeoutError:
             self.logger.debug("Caught timeouterror, cleaned up all we can")
+
         # purge the cleaned futures
         for future in futures_completed:
             self.journal_futures.pop(future)
 
     def wait_pulses(self, pulses, status=None):
         """Wait for the specified number of motor feedback pulses to occur
+
         Args:
-            pulses(int): The number of pulses to wait for.  Counting only starts after the first change in GPIO pulse state, and counts on transition from low to high
+            pulses(int): The number of pulses to wait for. Counting only starts after the first change in GPIO pulse state, and counts on transition from low to high
             status(str): If provided, this string status is used for status and journal updates
+
         Returns:
             success(bool): True if the operation was completed, False if the time limit was seen first
         """
@@ -154,164 +506,794 @@ class pimc:
         last_state = None
         start_time = time.time()
         last_pulse = start_time
+
         while time.time() - start_time < self.maxtime and pulses_seen < pulses:
             self.cleanup_completed_journal_futures()
             time.sleep(0.050)
             state = GPIO.input(PULSE)
-            #print(f"{time.time() - start_time} {state}" )
+
             # on first iteration, just read the state
             if last_state is None:
                 last_state = state
                 continue
+
             if state > last_state:
-                self.logger.debug("Pulse seen.  Now %s/%s", pulses_seen, pulses)
-                self.logger.debug("Time since last pulse: %s", time.time()-last_pulse)
+                self.logger.debug("Pulse seen. Now %s/%s", pulses_seen, pulses)
+                self.logger.debug("Time since last pulse: %s", time.time() - last_pulse)
                 last_pulse = time.time()
                 pulses_seen += 1
                 if status:
                     self.update_status(f"{status} {pulses-pulses_seen}")
+
             last_state = state
+
         if pulses_seen >= pulses:
-            return True # saw the pulses
-        return False # hit max motor runtime
+            return True  # saw the pulses
+        return False  # hit max motor runtime
+
     def fake_wait_pulses(self, pulses, status=None):
         """Fake waiting for the specified number of motor feedback pulses to occur, 1 second per fake pulse
+
         Args:
-            pulses(int): The number of pulses to wait for.  Counting only starts after the first change in GPIO pulse state, and counts on transition from low to high
+            pulses(int): The number of pulses to wait for. Counting only starts after the first change in GPIO pulse state, and counts on transition from low to high
             status(str): If provided, this string status is used for status and journal updates
+
         Returns:
             success(bool): True if the operation was completed, False if the time limit was seen first
-        """        # pulse is counted on change from low to high
+        """
+        # pulse is counted on change from low to high
         pulses_seen = 0
         last_state = None
         start_time = time.time()
+
         while time.time() - start_time < self.maxtime and pulses_seen < pulses:
             self.cleanup_completed_journal_futures()
             time.sleep(1)
-            last_state = 0 # for faking it
+            last_state = 0  # for faking it
             state = 1
-            #print(f"{time.time() - start_time} {state}" )
+
             # on first iteration, just read the state
             if last_state is None:
                 last_state = state
                 continue
+
             if state > last_state:
-                self.logger.debug("Pulse seen.  Now %s/%s", pulses_seen, pulses)
+                self.logger.debug("Pulse seen. Now %s/%s", pulses_seen, pulses)
                 pulses_seen += 1
                 if status:
                     self.update_status(f"{status} {pulses-pulses_seen}")
+
             last_state = state
+
         if pulses_seen >= pulses:
-            return True # saw the pulses
-        return False # hit max motor runtime
-    def gpio_setup(self):
-        """Perform GPIO input/output configuration.  Updates self.gpio_initialized; will avoid duplicate setups.
+            return True  # saw the pulses
+        return False  # hit max motor runtime
+
+    def read_position(self):
+        """Read the current motor position as a voltage from the ADC position sensor.
+
+        This method requires that a position_sensor was provided at instantiation.
+        Callers should check that self.position_sensor is not None before calling,
+        or catch the AttributeError that will result if it is.
+
         Args:
             None
+
+        Returns:
+            voltage(float): Current position in volts as returned by the sensor.
+        """
+        return self.position_sensor.read()
+
+    def is_fully_open(self):
+        """Determine whether the motor is at or past the fully open position.
+
+        Uses voltage_tolerance so that a motor that is physically stopped
+        just short of voltage_fully_open (due to potentiometer wear, mechanical
+        hard stops, or ADC noise) is still considered fully open.
+
+        Args:
+            None
+
+        Returns:
+            result(bool): True if current position is within tolerance of fully open
+                          or beyond it.
+        """
+        return self.read_position() >= (self.voltage_fully_open - self.voltage_tolerance)
+
+    def is_fully_closed(self):
+        """Determine whether the motor is at or past the fully closed position.
+
+        Uses voltage_tolerance for the same reasons as is_fully_open().
+
+        Args:
+            None
+
+        Returns:
+            result(bool): True if current position is within tolerance of fully closed
+                          or beyond it.
+        """
+        return self.read_position() <= (self.voltage_fully_closed + self.voltage_tolerance)
+
+    def run_until_voltage(self, target_voltage, direction):
+        """Run the motor until the ADC reads within tolerance of a target voltage.
+
+        This is the core analog-feedback motor control method. It is the voltage-based
+        counterpart to wait_pulses(), and follows a similar structure: run the motor,
+        poll feedback, stop on success or timeout.
+
+        The motor must already be running when this method is called (forward() or
+        reverse() should be called first). This method only watches the ADC and
+        decides when to declare success or fault — it does not start or stop the motor
+        itself, to match the structure of the existing wait_pulses() design.
+
+        Args:
+            target_voltage(float): The voltage to move toward. Success is declared
+                                   when abs(current - target) <= voltage_tolerance.
+            direction(str): Expected direction of voltage change. Must be 'increasing'
+                            (opening, voltage should rise) or 'decreasing' (closing,
+                            voltage should fall). Used for wrong-direction fault detection.
+
+        Returns:
+            success(bool): True if target reached within tolerance and time limit.
+                           False if timeout or direction fault occurred.
+
+        # --- Design notes on tolerance and direction fault detection ---
+        #
+        # TOLERANCE:
+        # We declare success when we are within voltage_tolerance of the target,
+        # rather than requiring an exact match. This is intentional and important
+        # for real-world hardware:
+        #
+        #   - Aging potentiometers may not produce perfectly repeatable voltages
+        #     at the same physical position, especially in humid environments.
+        #   - The motor may reach a mechanical hard stop slightly before or after
+        #     the electrical target voltage.
+        #   - ADC readings have inherent noise (typically a few millivolts at 10-bit
+        #     resolution with a 5V reference).
+        #
+        #   Without tolerance, the motor could time out on every single operation
+        #   because it can never hit the exact target. This would look like a fault
+        #   even when the physical system is working perfectly.
+        #
+        # DIRECTION FAULT DETECTION:
+        # After a settling period (direction_settle_seconds), we check whether the
+        # voltage is moving in the expected direction. If it has moved more than
+        # direction_fault_threshold volts the wrong way, we stop the motor and
+        # return failure.
+        #
+        # The settling delay is critical: immediately after the relays engage, there
+        # may be inrush effects, relay bounce, or mechanical lag before the motor
+        # starts turning. Checking direction too early would produce false faults.
+        #
+        # For applications where each motor move is short (50-200ms total), the
+        # settling period should be kept small relative to the total move time —
+        # e.g. 2x-3x poll_interval_seconds. A settling period that is a large
+        # fraction of total move time means direction faults can only be caught
+        # very late in the move, reducing the safety value of the check.
+        #
+        # IMPORTANT INTERACTION between tolerance and direction_fault_threshold:
+        # direction_fault_threshold must be greater than voltage_tolerance.
+        # If it is not, then normal ADC noise near the target voltage (which is
+        # within tolerance and should trigger success) could instead trigger a
+        # direction fault before the success condition is evaluated. This is checked
+        # at __init__ time with a logged warning. See __init__ for the full explanation.
+        #
+        # IMPORTANT INTERACTION between poll_interval_seconds and direction_settle_seconds:
+        # poll_interval_seconds should be less than direction_settle_seconds so that
+        # at least one ADC sample is taken during the settling window. If poll_interval
+        # >= direction_settle_seconds, the settling period is effectively zero — the
+        # first sample after loop start is already past the settle window. This is
+        # checked at __init__ time with a logged warning.
+        #
+        # TIMEOUT / STALL DETECTION:
+        # The timeout (self.maxtime) catches cases where the motor is running but
+        # voltage is not changing — for example, a mechanical bind that stalls the
+        # motor short of its target, or the motor hitting its internal hard limit
+        # before reaching the electrical target voltage. The timeout exit logs the
+        # final voltage, target, and tolerance so that the discrepancy is visible
+        # in logs for diagnosis.
+        """
+        if direction not in ('increasing', 'decreasing'):
+            raise ValueError(f"direction must be 'increasing' or 'decreasing', got '{direction}'")
+
+        start_time = time.time()
+        settling_complete = False
+        # Record the voltage at the moment we start, so we can evaluate direction
+        # of movement after the settling period has elapsed.
+        voltage_at_settle = None
+
+        while time.time() - start_time < self.maxtime:
+            self.cleanup_completed_journal_futures()
+            time.sleep(self.poll_interval_seconds)
+
+            current_voltage = self.read_position()
+            self.logger.debug("run_until_voltage: current=%.3fV target=%.3fV direction=%s", current_voltage, target_voltage, direction)
+
+            # --- Success check ---
+            # Check this before the direction fault check so that a reading that
+            # is within tolerance but technically a tiny bit in the wrong direction
+            # (pure ADC noise) does not trigger a false fault.
+            if abs(current_voltage - target_voltage) <= self.voltage_tolerance:
+                self.logger.info(
+                    "run_until_voltage: reached target. current=%.3fV target=%.3fV tolerance=%.3fV",
+                    current_voltage, target_voltage, self.voltage_tolerance
+                )
+                return True
+
+            # --- Settling period ---
+            # Do not perform direction checks until the motor has had time to
+            # start moving. Record the voltage once settling is complete so we
+            # have a stable baseline for direction comparison.
+            elapsed = time.time() - start_time
+            if not settling_complete:
+                if elapsed >= self.direction_settle_seconds:
+                    settling_complete = True
+                    voltage_at_settle = current_voltage
+                    self.logger.debug(
+                        "run_until_voltage: settling complete. voltage at settle=%.3fV", voltage_at_settle
+                    )
+                else:
+                    # Still in settling period, skip direction check this iteration.
+                    continue
+
+            # --- Direction fault check ---
+            # Compare current voltage against the voltage recorded at end of
+            # settling. If we have moved more than direction_fault_threshold in
+            # the wrong direction, something is wrong — stop and fault.
+            if direction == 'increasing' and current_voltage < (voltage_at_settle - self.direction_fault_threshold):
+                self.logger.error(
+                    "run_until_voltage: direction fault. Voltage is DECREASING but expected INCREASING. "
+                    "current=%.3fV settle_baseline=%.3fV fault_threshold=%.3fV",
+                    current_voltage, voltage_at_settle, self.direction_fault_threshold
+                )
+                return False
+
+            if direction == 'decreasing' and current_voltage > (voltage_at_settle + self.direction_fault_threshold):
+                self.logger.error(
+                    "run_until_voltage: direction fault. Voltage is INCREASING but expected DECREASING. "
+                    "current=%.3fV settle_baseline=%.3fV fault_threshold=%.3fV",
+                    current_voltage, voltage_at_settle, self.direction_fault_threshold
+                )
+                return False
+
+        # --- Timeout ---
+        # The motor ran for maxtime seconds without reaching the target.
+        # This may indicate a mechanical stall, a bind in the linkage, or the
+        # motor hitting its internal hard limit before the electrical target was
+        # reached. Log enough detail to diagnose the discrepancy.
+        current_voltage = self.read_position()
+        self.logger.error(
+            "run_until_voltage: timed out before reaching target. "
+            "current=%.3fV target=%.3fV tolerance=%.3fV maxtime=%ss",
+            current_voltage, target_voltage, self.voltage_tolerance, self.maxtime
+        )
+        return False
+
+    def open_increment(self):
+        """Move the motor open by one voltage increment.
+
+        Reads current position, computes a target voltage one increment higher,
+        caps it at voltage_fully_open, and runs the motor until that target is
+        reached (within tolerance) or a fault occurs.
+
+        Requires voltage_increment to be set at construction time. If it is None,
+        a clear error is logged and False is returned.
+
+        If the motor is already at or past the fully open position (within
+        tolerance), no movement is attempted.
+
+        Args:
+            None
+
+        Returns:
+            success(bool): True if the increment was completed successfully.
+                           False if already fully open, voltage_increment not set,
+                           or if a fault occurred.
+        """
+        if self.voltage_increment is None:
+            self.logger.error(
+                "open_increment: voltage_increment is not set. "
+                "Provide voltage_increment at construction time to use open_increment()."
+            )
+            return False
+
+        if self.is_fully_open():
+            self.logger.info("open_increment: already at fully open position, not moving")
+            return False
+
+        current_voltage = self.read_position()
+
+        # Compute target: one increment up, but no further than fully open.
+        # This means the final increment may be smaller than voltage_increment
+        # if we are close to the open limit — we move to fully open rather than
+        # stopping short just because a full increment would overshoot.
+        target_voltage = min(current_voltage + self.voltage_increment, self.voltage_fully_open)
+        self.logger.info(
+            "open_increment: current=%.3fV target=%.3fV fully_open=%.3fV",
+            current_voltage, target_voltage, self.voltage_fully_open
+        )
+
+        if not self.forward():
+            self.logger.error("open_increment: aborted, motor busy")
+            return False
+
+        result = self.run_until_voltage(target_voltage, direction='increasing')
+        self.stop_and_housekeeping()
+
+        if not result:
+            self.logger.error("open_increment: failed to reach target voltage")
+            self.update_status("failed opening", use_future=False)
+        return result
+
+    def close_increment(self):
+        """Move the motor closed by one voltage increment.
+
+        Reads current position, computes a target voltage one increment lower,
+        caps it at voltage_fully_closed, and runs the motor until that target is
+        reached (within tolerance) or a fault occurs.
+
+        Requires voltage_increment to be set at construction time. If it is None,
+        a clear error is logged and False is returned.
+
+        If the motor is already at or past the fully closed position (within
+        tolerance), no movement is attempted.
+
+        Args:
+            None
+
+        Returns:
+            success(bool): True if the increment was completed successfully.
+                           False if already fully closed, voltage_increment not set,
+                           or if a fault occurred.
+        """
+        if self.voltage_increment is None:
+            self.logger.error(
+                "close_increment: voltage_increment is not set. "
+                "Provide voltage_increment at construction time to use close_increment()."
+            )
+            return False
+
+        if self.is_fully_closed():
+            self.logger.info("close_increment: already at fully closed position, not moving")
+            return False
+
+        current_voltage = self.read_position()
+
+        # Compute target: one increment down, but no lower than fully closed.
+        # Same partial-increment logic as open_increment — move to fully closed
+        # rather than stopping short when within one increment of the limit.
+        target_voltage = max(current_voltage - self.voltage_increment, self.voltage_fully_closed)
+        self.logger.info(
+            "close_increment: current=%.3fV target=%.3fV fully_closed=%.3fV",
+            current_voltage, target_voltage, self.voltage_fully_closed
+        )
+
+        if not self.reverse():
+            self.logger.error("close_increment: aborted, motor busy")
+            return False
+
+        result = self.run_until_voltage(target_voltage, direction='decreasing')
+        self.stop_and_housekeeping()
+
+        if not result:
+            self.logger.error("close_increment: failed to reach target voltage")
+            self.update_status("failed closing", use_future=False)
+        return result
+
+    def _require_position_sensor(self, action_name):
+        """Check that a position_sensor is configured, logging a clear error if not.
+
+        Used by voltage-based action methods to provide a consistent, informative
+        error when the CLI is invoked with a voltage action but --vref (and therefore
+        a position_sensor) was not provided.
+
+        Args:
+            action_name(str): The name of the calling action, for the error message.
+
+        Returns:
+            has_sensor(bool): True if position_sensor is configured, False otherwise.
+        """
+        if self.position_sensor is None:
+            self.logger.error(
+                "%s requires a position sensor (ADC). "
+                "Provide --vref on the command line to enable ADC position feedback. "
+                "Also ensure --fully-open-voltage and --fully-closed-voltage are specified.",
+                action_name
+            )
+            return False
+        return True
+
+    def _require_positive_delta(self, action_name, delta, arg_name):
+        """Validate that a voltage delta argument is a positive non-zero value.
+
+        Voltage delta arguments (--open-voltage, --close-voltage) must be positive
+        absolute values. The direction of movement is implied by the action chosen,
+        not by the sign of the delta. A negative or zero value is always a user error:
+          - Zero would be a no-op that silently appears to succeed.
+          - Negative would move the motor in the opposite direction from what the
+            action name implies, causing confusing and potentially unsafe behavior.
+
+        Args:
+            action_name(str): The name of the calling action, for the error message.
+            delta(float or None): The delta value to validate.
+            arg_name(str): The CLI argument name, for the error message.
+
+        Returns:
+            valid(bool): True if delta is a positive non-zero float, False otherwise.
+        """
+        if delta is None:
+            self.logger.error(
+                "%s requires %s to be specified. "
+                "Provide a positive voltage delta (e.g. %s 0.5).",
+                action_name, arg_name, arg_name
+            )
+            return False
+        if delta <= 0:
+            self.logger.error(
+                "%s: %s must be a positive non-zero value, got %.3f. "
+                "Always provide an absolute (positive) voltage delta — "
+                "the direction of movement is determined by the action, not the sign of the delta.",
+                action_name, arg_name, delta
+            )
+            return False
+        return True
+
+    def action_open_voltage(self):
+        """Open the motor by a voltage delta from current position.
+
+        Reads current position, adds the configured open_voltage delta, caps at
+        voltage_fully_open, and drives the motor forward until the target is reached.
+
+        Requires --vref (position sensor) and --open-voltage to be provided on the CLI.
+        --open-voltage must be a positive absolute value; the open direction is implied
+        by this action. --fully-open-voltage is used as the upper bound.
+
+        Args:
+            None
+
+        Returns:
+            result(bool or None): True on success, False on fault, None if misconfigured.
+        """
+        if not self._require_position_sensor("action_open_voltage"):
+            return None
+        if not self._require_positive_delta("action_open_voltage", self.open_voltage, "--open-voltage"):
+            return None
+
+        if self.is_fully_open():
+            self.logger.info("action_open_voltage: already at fully open position, not moving")
+            return True
+
+        current_voltage = self.read_position()
+        # Cap target at voltage_fully_open so a large delta cannot drive the motor
+        # past its defined open limit.
+        target_voltage = min(current_voltage + self.open_voltage, self.voltage_fully_open)
+        self.logger.info(
+            "action_open_voltage: current=%.3fV delta=%.3fV target=%.3fV fully_open=%.3fV",
+            current_voltage, self.open_voltage, target_voltage, self.voltage_fully_open
+        )
+
+        if not self.forward():
+            self.logger.error("action_open_voltage: aborted, motor busy")
+            return False
+
+        result = self.run_until_voltage(target_voltage, direction='increasing')
+        self.stop_and_housekeeping()
+
+        if not result:
+            self.logger.error("action_open_voltage: failed to reach target voltage")
+            self.update_status("failed opening", use_future=False)
+        return result
+
+    def action_close_voltage(self):
+        """Close the motor by a voltage delta from current position.
+
+        Reads current position, subtracts the configured close_voltage delta, caps at
+        voltage_fully_closed, and drives the motor in reverse until the target is reached.
+
+        Requires --vref (position sensor) and --close-voltage to be provided on the CLI.
+        --close-voltage must be a positive absolute value; the close direction is implied
+        by this action and the delta is subtracted internally. --fully-closed-voltage is
+        used as the lower bound.
+
+        Args:
+            None
+
+        Returns:
+            result(bool or None): True on success, False on fault, None if misconfigured.
+        """
+        if not self._require_position_sensor("action_close_voltage"):
+            return None
+        if not self._require_positive_delta("action_close_voltage", self.close_voltage, "--close-voltage"):
+            return None
+
+        if self.is_fully_closed():
+            self.logger.info("action_close_voltage: already at fully closed position, not moving")
+            return True
+
+        current_voltage = self.read_position()
+        # Cap target at voltage_fully_closed so a large delta cannot drive the motor
+        # past its defined closed limit.
+        target_voltage = max(current_voltage - self.close_voltage, self.voltage_fully_closed)
+        self.logger.info(
+            "action_close_voltage: current=%.3fV delta=%.3fV target=%.3fV fully_closed=%.3fV",
+            current_voltage, self.close_voltage, target_voltage, self.voltage_fully_closed
+        )
+
+        if not self.reverse():
+            self.logger.error("action_close_voltage: aborted, motor busy")
+            return False
+
+        result = self.run_until_voltage(target_voltage, direction='decreasing')
+        self.stop_and_housekeeping()
+
+        if not result:
+            self.logger.error("action_close_voltage: failed to reach target voltage")
+            self.update_status("failed closing", use_future=False)
+        return result
+
+    def action_fully_open_voltage(self):
+        """Drive the motor to the fully open voltage position.
+
+        Requires a position_sensor (--vref must be provided on the CLI).
+        The target position is set by --fully-open-voltage / voltage_fully_open.
+        Drives the motor forward until voltage_fully_open is reached within
+        voltage_tolerance, or until maxtime is exceeded.
+
+        Args:
+            None
+
+        Returns:
+            result(bool or None): True if fully open position reached, False on fault
+                                  or timeout, None if no sensor configured.
+        """
+        if not self._require_position_sensor("action_fully_open_voltage"):
+            return None
+
+        if self.is_fully_open():
+            self.logger.info("action_fully_open_voltage: already at fully open position, not moving")
+            return True
+
+        current_voltage = self.read_position()
+        self.logger.info(
+            "action_fully_open_voltage: current=%.3fV target=%.3fV (fully open)",
+            current_voltage, self.voltage_fully_open
+        )
+
+        if not self.forward():
+            self.logger.error("action_fully_open_voltage: aborted, motor busy")
+            return False
+
+        result = self.run_until_voltage(self.voltage_fully_open, direction='increasing')
+        self.stop_and_housekeeping()
+
+        if not result:
+            self.logger.error("action_fully_open_voltage: failed to reach fully open position")
+            self.update_status("failed opening", use_future=False)
+        else:
+            self.update_status("open", use_future=False)
+        return result
+
+    def action_fully_close_voltage(self):
+        """Drive the motor to the fully closed voltage position.
+
+        Requires a position_sensor (--vref must be provided on the CLI).
+        The target position is set by --fully-closed-voltage / voltage_fully_closed.
+        Drives the motor in reverse until voltage_fully_closed is reached within
+        voltage_tolerance, or until maxtime is exceeded.
+
+        Args:
+            None
+
+        Returns:
+            result(bool or None): True if fully closed position reached, False on fault
+                                  or timeout, None if no sensor configured.
+        """
+        if not self._require_position_sensor("action_fully_close_voltage"):
+            return None
+
+        if self.is_fully_closed():
+            self.logger.info("action_fully_close_voltage: already at fully closed position, not moving")
+            return True
+
+        current_voltage = self.read_position()
+        self.logger.info(
+            "action_fully_close_voltage: current=%.3fV target=%.3fV (fully closed)",
+            current_voltage, self.voltage_fully_closed
+        )
+
+        if not self.reverse():
+            self.logger.error("action_fully_close_voltage: aborted, motor busy")
+            return False
+
+        result = self.run_until_voltage(self.voltage_fully_closed, direction='decreasing')
+        self.stop_and_housekeeping()
+
+        if not result:
+            self.logger.error("action_fully_close_voltage: failed to reach fully closed position")
+            self.update_status("failed closing", use_future=False)
+        else:
+            self.update_status("closed", use_future=False)
+        return result
+
+    def gpio_setup(self):
+        """Perform GPIO input/output configuration. Updates self.gpio_initialized; will avoid duplicate setups.
+
+        Args:
+            None
+
         Returns:
             initialization_performed(bool): False if initialization was already done, True if it was performed on this call
         """
         if self.gpio_initialized:
             return False
-        # 26, CH1, is lead1
-        # 20, CH2,  is lead2
-        # LOW enables the relay, sends power
-        # HIGH disables the relay, sends ground
-        GPIO.setup(CH1, GPIO.OUT)
-        GPIO.setup(CH2, GPIO.OUT)
-        GPIO.setup(PULSE, GPIO.IN)
+
+        # Use instance pin attributes rather than module-level constants, so that
+        # pins can be configured at instantiation without changing the defaults.
+        GPIO.setup(self.ch1_pin, GPIO.OUT)
+        GPIO.setup(self.ch2_pin, GPIO.OUT)
+
+        # Only set up the pulse input pin if we are using pulse-based feedback.
+        # When a position_sensor is provided, pulse counting is not used and
+        # the PULSE pin is not needed.
+        if self.position_sensor is None:
+            GPIO.setup(PULSE, GPIO.IN)
+
         self.gpio_initialized = True
         return True
+
     def get_status(self):
         return self.status
+
     def forward(self):
-        """Run motor in the forward direction
+        """Run motor in the forward direction.
+
+        In 'independent' mode: sets CH1 LOW (original behavior).
+        In 'enable_direction' mode: sets CH2 LOW (direction select), then
+        sets CH1 LOW (enable neutral). CH2 is set before CH1 to ensure the
+        direction is selected before the motor is energized.
+
+        The physical meaning of "forward" (which direction the motor turns)
+        is determined entirely by wiring and is not defined here.
+
         Args:
             None
+
         Returns:
-            None
+            success(bool): False if motor is already busy, True otherwise.
         """
-        # call stop() to ensure both are HIGH
-        # then set CH1 to LOW
         if self.motor_busy:
             return False
         self.motor_busy = True
         self.stop_and_housekeeping()
         if self.faking_it:
             return True
-        GPIO.output(CH1, 0)
+        if self.relay_mode == 'enable_direction':
+            # Set direction first, then enable neutral.
+            # This ensures the motor starts in the correct direction
+            # rather than briefly running the wrong way on energization.
+            GPIO.output(self.ch2_pin, 0)   # direction: forward
+            GPIO.output(self.ch1_pin, 0)   # enable neutral
+        else:
+            GPIO.output(self.ch1_pin, 0)
         return True
+
     def reverse(self):
-        """Run motor in the reverse direction
+        """Run motor in the reverse direction.
+
+        In 'independent' mode: sets CH2 LOW (original behavior).
+        In 'enable_direction' mode: sets CH2 HIGH (direction select), then
+        sets CH1 LOW (enable neutral). CH2 is set before CH1 to ensure the
+        direction is selected before the motor is energized.
+
+        The physical meaning of "reverse" (which direction the motor turns)
+        is determined entirely by wiring and is not defined here.
+
         Args:
             None
+
         Returns:
-            None
+            success(bool): False if motor is already busy, True otherwise.
         """
-        # call stop() to ensure both are HIGH
-        # then set CH2 to LOW
         if self.motor_busy:
             return False
         self.motor_busy = True
         self.stop_and_housekeeping()
         if self.faking_it:
             return True
-        GPIO.output(CH2, 0)
+        if self.relay_mode == 'enable_direction':
+            # Set direction first, then enable neutral.
+            GPIO.output(self.ch2_pin, 1)   # direction: reverse
+            GPIO.output(self.ch1_pin, 0)   # enable neutral
+        else:
+            GPIO.output(self.ch2_pin, 0)
         return True
 
     def stop_and_housekeeping(self):
-        """Ensure output is stopped, and block to wait for any pending housekeeping/journal futures needing cleanup
+        """Ensure output is stopped, and block to wait for any pending housekeeping/journal futures needing cleanup.
+
+        In 'enable_direction' mode, the neutral/enable relay (CH1) is dropped
+        before the direction relay (CH2) is changed. This is the correct
+        sequencing for AC motors with separate directional windings: removing
+        power before changing direction avoids the motor attempting to reverse
+        under load, which causes mechanical shock and inrush current.
+
+        In 'independent' mode, both relays are set HIGH simultaneously,
+        preserving the original behavior.
+
         Args:
             None
+
         Returns:
             None
         """
-        # both HIGH => ground/negative
         self.gpio_setup()
-        GPIO.output(CH1, 1)
-        GPIO.output(CH2, 1)
+
+        if self.relay_mode == 'enable_direction':
+            # Drop neutral first, then set direction relay to a known state.
+            # The direction relay state after stop is intentionally left as HIGH
+            # (same as independent mode idle state) for consistency, but its
+            # value is irrelevant while neutral (CH1) is HIGH/disabled.
+            GPIO.output(self.ch1_pin, 1)   # disable neutral first
+            time.sleep(0.05)               # brief delay to ensure motor is de-energized
+            GPIO.output(self.ch2_pin, 1)   # direction relay to idle state
+        else:
+            # Original behavior: both HIGH simultaneously.
+            GPIO.output(self.ch1_pin, 1)
+            GPIO.output(self.ch2_pin, 1)
+
         time.sleep(0.25)
         self.motor_busy = False
+
         for future in concurrent.futures.as_completed(self.journal_futures):
             self.logger.debug("Cleaned up future %s", self.journal_futures[future])
         # purge futures data structure
         self.journal_futures = {}
+
     def action_open_pulses(self):
         """
         Handle user open-pulses request based on configuration
         """
-        return self.open(pulses=self.pulses)
+        return self.open(pulses=self.open_pulses)
+
     def action_open_seconds(self):
         """
         Handle user open-seconds request based on configuration
         """
         return self.open(seconds=self.open_seconds)
+
     def open(self, pulses=None, seconds=None, resuming=False):
         """Run the motor the specified number of pulses to the fully-opened position
+
         Args:
-            pulses(int): The number of pulses to run.  If not specified, the full number of pulses is used
+            pulses(int): The number of pulses to run. If not specified, the full number of pulses is used
             resuming(bool): Specifies whether this operation is resuming an interrupted operation, to perform proper checks and status/journal updates
-        """        
+        """
         if not resuming:
             if self.status != "closed":
                 print(f"Journal says status is {self.status}, not opening")
                 return False
+
         if not self.forward():
             self.logger("Aborted open: motor busy")
             return False
+
         if not resuming:
             self.update_status("opening")
+
         if pulses:
             self.logger.debug("Waiting %s pulses", pulses)
             if self.faking_it:
                 result = self.fake_wait_pulses(pulses, status="opening")
             else:
                 result = self.wait_pulses(pulses, status="opening")
+
         if seconds:
             self.logger.debug("Waiting %s seconds", seconds)
             time.sleep(seconds)
             result = True
+
         self.stop_and_housekeeping()
+
         if result:
             print("Opened")
             self.update_status("open", use_future=False)
@@ -320,20 +1302,24 @@ class pimc:
             print("FAILED during open, hit max runtime")
             self.update_status("failed opening", use_future=False)
             return False
+
     def action_close_pulses(self):
         """
         Handle user close-pulses request based on configuration
         """
-        return self.close(pulses=self.pulses)
+        return self.close(pulses=self.close_pulses)
+
     def action_close_seconds(self):
         """
         Handle user close-seconds request based on configuration
         """
         return self.close(seconds=self.close_seconds)
+
     def close(self, pulses=None, seconds=None, resuming=False):
         """Run the motor the specified number of pulses to the fully-closed position
+
         Args:
-            pulses(int): The number of pulses to run.  If not specified, the full number of pulses is used
+            pulses(int): The number of pulses to run. If not specified, the full number of pulses is used
             resuming(bool): Specifies whether this operation is resuming an interrupted operation, to perform proper checks and status/journal updates
         """
         self.logger.info("Closing....")
@@ -341,20 +1327,26 @@ class pimc:
             if self.status != "open":
                 print(f"Journal says status is {self.status}, not closing")
                 return False
+
         if not self.reverse():
             self.logger("Aborted close: motor busy")
             return False
+
         if not resuming:
             self.update_status("closing")
+
         if pulses:
             if self.faking_it:
                 result = self.fake_wait_pulses(pulses, status="closing")
             else:
                 result = self.wait_pulses(pulses, "closing")
+
         if seconds:
             time.sleep(seconds)
             result = True
+
         self.stop_and_housekeeping()
+
         if result:
             print("Closed")
             self.update_status("closed", use_future=False)
@@ -363,6 +1355,7 @@ class pimc:
             print("FAILED during close, hit max runtime")
             self.update_status("failed closing", use_future=False)
             return False
+
     def action_status(self):
         """Print the current system status"""
         print(self.status)
@@ -370,42 +1363,149 @@ class pimc:
     def run(self, action):
         """
         Run the requested action
+
         Args:
             action(str): Requested action
+
         Returns:
             action_output: Return value from the action's callable
         """
         callable_name = f"action_{action.replace('-','_')}"
         self.logger.debug("action callable_name: %s", callable_name)
         action_callable = getattr(motorcontrol, callable_name) if hasattr(motorcontrol, callable_name) else None
+
         if action_callable is None:
             self.logger.error("Could not find method for requested action `%s`", action)
             return None
+
         if not callable(action_callable):
             self.logger.error("%s is not callable", callable_name)
         action_callable()
-            
+
 
 if __name__ == "__main__":
+
     def get_action_choices():
         action_attributes = [attribute for attribute in dir(pimc) if attribute[0:7] == 'action_']
-        availble_actions = []
+        available_actions = []
         for attribute in action_attributes:
             if len(attribute) <= 7:
                 continue
-            availble_actions.append(attribute.replace('_','-'))
-    
-    parser = argparse.ArgumentParser()
-    parser.add_argument("action", action="store", choices=get_action_choices())
-    parser.add_argument("--resume", action="store_true", help="Resume any prior journaled action before taking new action")
-    parser.add_argument("--close-pulses", action="store", type=int, default=11, help="Override the number of pulses to close")
-    parser.add_argument("--open-pulses", action="store", type=int, default=11, help="Override the number of pulses to open")
-    parser.add_argument("--close-seconds", action="store", type=int, default=None, help="Override the number of seconds to close")
-    parser.add_argument("--open-seconds", action="store", type=int, default=None, help="Override the number of seconds to open")
-    parser.add_argument("--max-time", action="store", type=int, default=30, help="Maximum motor runtime per operation, in seconds")
-    parser.add_argument("--journal-filename", default="pimc_status", action="store", help="Path to the journal file")
-    parser.add_argument("--fake", action="store_true", help="Fake all motor/GPIO interactions")
-    parser.add_argument("--debug", action="store_true", help="Verbose logging for debugging")
+            available_actions.append(attribute[7:].replace('_', '-'))
+        return available_actions
+
+    parser = argparse.ArgumentParser(
+        description="pimotorcontrol CLI — motor control swiss army knife for Raspberry Pi relay hats.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+actions:
+  open-pulses           Open motor by pulse count (--open-pulses)
+  close-pulses          Close motor by pulse count (--close-pulses)
+  open-seconds          Open motor by time (--open-seconds)
+  close-seconds         Close motor by time (--close-seconds)
+  open-voltage          Open motor by voltage delta from current position (--open-voltage, requires --vref)
+  close-voltage         Close motor by voltage delta from current position (--close-voltage, requires --vref)
+  fully-open-voltage    Drive motor to fully open voltage position (--fully-open-voltage, requires --vref)
+  fully-close-voltage   Drive motor to fully closed voltage position (--fully-closed-voltage, requires --vref)
+  status                Print current journal status
+
+relay modes:
+  independent           CH1 and CH2 each drive one motor lead (original DC wiper motor wiring)
+  enable_direction      CH1 enables neutral/common; CH2 selects direction (AC motor wiring)
+
+voltage delta arguments (--open-voltage, --close-voltage):
+  Always provide a positive absolute value. The direction of movement is determined
+  by the action chosen, not the sign of the delta. The code subtracts the delta
+  internally for close operations. A negative or zero value is an error.
+        """
+    )
+    parser.add_argument("action", action="store", choices=get_action_choices(),
+                        help="Action to perform (see action list below)")
+
+    # --- required args (no defaults, intentional) ---
+    parser.add_argument("--relay-mode", action="store", required=True,
+                        choices=pimc.RELAY_MODES,
+                        help="Relay wiring mode. REQUIRED: no default assumed due to physical wiring "
+                             "consequences. 'independent' for DC motors (original behavior); "
+                             "'enable_direction' for AC motors with separate forward/reverse leads.")
+
+    # --- journal / general ---
+    parser.add_argument("--resume", action="store_true",
+                        help="Resume any prior journaled action before taking new action")
+    parser.add_argument("--journal-filename", default="pimc_status", action="store",
+                        help="Path to the journal file (default: pimc_status)")
+    parser.add_argument("--fake", action="store_true",
+                        help="Fake all motor/GPIO interactions for testing")
+    parser.add_argument("--debug", action="store_true",
+                        help="Verbose logging for debugging")
+    parser.add_argument("--max-time", action="store", type=int, default=30,
+                        help="Maximum motor runtime per operation in seconds (default: 30)")
+
+    # --- pulse-based args ---
+    parser.add_argument("--close-pulses", action="store", type=int, default=11,
+                        help="Number of pulses for close operation (default: 11)")
+    parser.add_argument("--open-pulses", action="store", type=int, default=11,
+                        help="Number of pulses for open operation (default: 11)")
+
+    # --- time-based args ---
+    parser.add_argument("--close-seconds", action="store", type=float, default=None,
+                        help="Seconds to run motor for close operation")
+    parser.add_argument("--open-seconds", action="store", type=float, default=None,
+                        help="Seconds to run motor for open operation")
+
+    # --- voltage/ADC args ---
+    # --vref is mandatory when any voltage-based action is used. It is not marked
+    # required=True in argparse because argparse cannot express conditional requirements
+    # based on the chosen action. Instead, the action methods check for a configured
+    # position_sensor via _require_position_sensor() and emit a clear error if absent.
+    # --vref is the trigger: when provided, an MCP3008PositionSensor is constructed
+    # and passed to pimc, enabling all voltage-based actions.
+    parser.add_argument("--vref", action="store", type=float, default=None,
+                        help="ADC reference voltage in volts. REQUIRED for all voltage-based actions. "
+                             "Must match the voltage supplied to the MCP3008 VREF pin exactly. "
+                             "No default is provided — an incorrect value produces incorrect "
+                             "position readings and unpredictable motor behavior.")
+    parser.add_argument("--adc-channel", action="store", type=int, default=0,
+                        help="MCP3008 analog input channel for position feedback (default: 0)")
+    parser.add_argument("--open-voltage", action="store", type=float, default=None,
+                        help="Positive voltage delta to move toward open from current position. "
+                             "Must be a positive absolute value — the open direction is implied "
+                             "by the open-voltage action. The motor runs forward until "
+                             "current_voltage + OPEN_VOLTAGE is reached (capped at --fully-open-voltage).")
+    parser.add_argument("--close-voltage", action="store", type=float, default=None,
+                        help="Positive voltage delta to move toward closed from current position. "
+                             "Must be a positive absolute value — the close direction is implied "
+                             "by the close-voltage action and the delta is subtracted internally. "
+                             "The motor runs in reverse until current_voltage - CLOSE_VOLTAGE is "
+                             "reached (capped at --fully-closed-voltage).")
+    parser.add_argument("--fully-open-voltage", action="store", type=float, default=None,
+                        help="Voltage at the fully open position. Used as the target for "
+                             "fully-open-voltage action and as the upper bound for open-voltage. "
+                             "Required for all voltage-based actions.")
+    parser.add_argument("--fully-closed-voltage", action="store", type=float, default=None,
+                        help="Voltage at the fully closed position. Used as the target for "
+                             "fully-close-voltage action and as the lower bound for close-voltage. "
+                             "Required for all voltage-based actions.")
+    parser.add_argument("--voltage-tolerance", action="store", type=float, default=0.1,
+                        help="Acceptable margin in volts for reaching a target voltage (default: 0.1). "
+                             "Accounts for potentiometer wear and ADC noise.")
+    parser.add_argument("--direction-fault-threshold", action="store", type=float, default=0.1,
+                        help="Volts of wrong-direction movement that triggers a fault (default: 0.1). "
+                             "Should be greater than --voltage-tolerance to avoid false faults from "
+                             "ADC noise near the target voltage.")
+    parser.add_argument("--direction-settle", action="store", type=float, default=0.1,
+                        help="Seconds to wait after motor start before checking direction (default: 0.1). "
+                             "Should be greater than --poll-interval.")
+    parser.add_argument("--poll-interval", action="store", type=float, default=0.05,
+                        help="Seconds between ADC reads in the position feedback loop (default: 0.05). "
+                             "Should be less than --direction-settle.")
+
+    # --- GPIO pin overrides ---
+    parser.add_argument("--ch1-pin", action="store", type=int, default=CH1,
+                        help=f"BCM GPIO pin for relay channel 1 (default: {CH1})")
+    parser.add_argument("--ch2-pin", action="store", type=int, default=CH2,
+                        help=f"BCM GPIO pin for relay channel 2 (default: {CH2})")
+
     logger = logging.getLogger(__name__)
     args = parser.parse_args()
 
@@ -414,9 +1514,43 @@ if __name__ == "__main__":
     else:
         logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 
-    motorcontrol = pimc(fake_it=args.fake, open_pulses=args.open_pulses, close_pulses=args.close_pulses, maxtime=args.max_time, logger=logger, resume=args.resume, journal_filename=args.journal_filename, open_seconds=args.open_seconds, close_seconds=args.close_seconds)
-    action = args.action.lower().strip()
+    # --- Construct position sensor if --vref was provided ---
+    # All four voltage actions require a sensor. If --vref is absent and a voltage
+    # action is requested, the action method will emit a clear error via
+    # _require_position_sensor() rather than failing with a less informative traceback.
+    position_sensor = None
+    if args.vref is not None:
+        position_sensor = MCP3008PositionSensor(channel=args.adc_channel, vref=args.vref)
 
+    motorcontrol = pimc(
+        fake_it=args.fake,
+        open_pulses=args.open_pulses,
+        close_pulses=args.close_pulses,
+        maxtime=args.max_time,
+        logger=logger,
+        resume=args.resume,
+        journal_filename=args.journal_filename,
+        open_seconds=args.open_seconds,
+        close_seconds=args.close_seconds,
+        position_sensor=position_sensor,
+        voltage_fully_open=args.fully_open_voltage,
+        voltage_fully_closed=args.fully_closed_voltage,
+        voltage_tolerance=args.voltage_tolerance,
+        direction_fault_threshold=args.direction_fault_threshold,
+        direction_settle_seconds=args.direction_settle,
+        poll_interval_seconds=args.poll_interval,
+        ch1_pin=args.ch1_pin,
+        ch2_pin=args.ch2_pin,
+        relay_mode=args.relay_mode,
+    )
+
+    # Store per-action voltage deltas directly on the instance so that
+    # action_open_voltage and action_close_voltage can access them.
+    # These are CLI-only concepts and are not constructor parameters.
+    motorcontrol.open_voltage = args.open_voltage
+    motorcontrol.close_voltage = args.close_voltage
+
+    action = args.action.lower().strip()
     try:
         motorcontrol.run(action)
     except KeyboardInterrupt:

--- a/pimotorcontrol.py
+++ b/pimotorcontrol.py
@@ -145,15 +145,28 @@ class MCP3008PositionSensor:
 #
 # The result is clamped to 0-100 to handle readings that drift slightly outside
 # the configured voltage range due to potentiometer wear or ADC noise.
+#
+# When voltage_tolerance is provided, readings within tolerance of either limit
+# are clamped to exactly 0.0 or 100.0, reflecting the same at-limit decision
+# that is_fully_open() and is_fully_closed() would make for the same reading.
 # -----------------------------------------------------------------------------
 
-def voltage_to_pct(voltage, voltage_fully_closed, voltage_fully_open):
+def voltage_to_pct(voltage, voltage_fully_closed, voltage_fully_open, voltage_tolerance=0.0):
     """Convert a potentiometer voltage reading to a percentage-open value.
 
     Calculates where the given voltage falls within the configured travel range
     (voltage_fully_closed to voltage_fully_open) and returns it as a percentage.
     Result is clamped to 0-100 to handle readings that drift slightly outside
     the configured range due to potentiometer wear or ADC noise.
+
+    When voltage_tolerance is provided, readings within that tolerance of either
+    limit are clamped to exactly 0.0 or 100.0. This reflects the real-world
+    behavior of the motor control logic: if the system considers the motor to be
+    fully open or fully closed (i.e. within tolerance of the limit), the reported
+    percentage should reflect that state rather than showing e.g. 98.3% when the
+    system has decided the motor is at the fully open position. Without this, the
+    percentage would appear to contradict the control decisions being logged and
+    emitted as telemetry events.
 
     This function does not read the ADC — the caller is responsible for
     providing a voltage reading. This allows callers that already have a cached
@@ -164,14 +177,30 @@ def voltage_to_pct(voltage, voltage_fully_closed, voltage_fully_open):
         voltage(float): The potentiometer voltage reading to convert, in volts.
         voltage_fully_closed(float): The voltage corresponding to 0% open (fully closed).
         voltage_fully_open(float): The voltage corresponding to 100% open (fully open).
+        voltage_tolerance(float): Acceptable margin in volts at either limit. Readings
+                                  within this tolerance of voltage_fully_open are reported
+                                  as 100.0%; readings within tolerance of voltage_fully_closed
+                                  are reported as 0.0%. Defaults to 0.0 for backward
+                                  compatibility with callers that do not pass tolerance.
 
     Returns:
-        pct(float): Percentage open, clamped to 0.0-100.0.
+        pct(float): Percentage open, clamped to 0.0-100.0. Exactly 0.0 or 100.0
+                    when within voltage_tolerance of either limit.
     """
     travel = voltage_fully_open - voltage_fully_closed
     if travel == 0:
         # Avoid division by zero if misconfigured thresholds are identical.
         return 0.0
+
+    # Apply tolerance clamping at limits before calculating percentage.
+    # This ensures the reported percentage reflects the same at-limit decision
+    # that is_fully_open() and is_fully_closed() would make for the same reading.
+    if voltage_tolerance > 0.0:
+        if voltage >= (voltage_fully_open - voltage_tolerance):
+            return 100.0
+        if voltage <= (voltage_fully_closed + voltage_tolerance):
+            return 0.0
+
     pct = (voltage - voltage_fully_closed) / travel * 100.0
     return max(0.0, min(100.0, pct))
 
@@ -640,26 +669,31 @@ class pimc:
 
         Convenience method for callers that want a percentage and do not already
         have a cached voltage reading. Calls read_position() once and passes the
-        result to voltage_to_pct().
+        result to voltage_to_pct() along with the configured voltage_tolerance,
+        so that readings within tolerance of either limit are reported as exactly
+        0.0% or 100.0% — consistent with the at-limit decisions made by
+        is_fully_open() and is_fully_closed().
 
         Callers that already have a fresh voltage reading (e.g. after a move
         completes) should call voltage_to_pct() directly with the cached value
         rather than calling this method, to avoid a second ADC read that could
         return a slightly different value due to pot wiper noise.
 
-        Requires position_sensor, voltage_fully_closed, and voltage_fully_open
-        to be configured at instantiation.
+        Requires position_sensor, voltage_fully_closed, voltage_fully_open,
+        and voltage_tolerance to be configured at instantiation.
 
         Args:
             None
 
         Returns:
             pct(float): Current position as percentage open, clamped to 0.0-100.0.
+                        Exactly 0.0 or 100.0 when within voltage_tolerance of either limit.
         """
         return voltage_to_pct(
             self.read_position(),
             self.voltage_fully_closed,
-            self.voltage_fully_open
+            self.voltage_fully_open,
+            self.voltage_tolerance,
         )
 
     def is_fully_open(self, current_voltage=None):
@@ -906,7 +940,7 @@ class pimc:
         # logging, avoiding two ADC reads that could return differing values
         # due to pot wiper noise.
         final_voltage = self.read_position()
-        final_pct = voltage_to_pct(final_voltage, self.voltage_fully_closed, self.voltage_fully_open)
+        final_pct = voltage_to_pct(final_voltage, self.voltage_fully_closed, self.voltage_fully_open, self.voltage_tolerance)
 
         if not result:
             self.logger.error(
@@ -978,7 +1012,7 @@ class pimc:
         # logging, avoiding two ADC reads that could return differing values
         # due to pot wiper noise.
         final_voltage = self.read_position()
-        final_pct = voltage_to_pct(final_voltage, self.voltage_fully_closed, self.voltage_fully_open)
+        final_pct = voltage_to_pct(final_voltage, self.voltage_fully_closed, self.voltage_fully_open, self.voltage_tolerance)
 
         if not result:
             self.logger.error(

--- a/pimotorcontrol.py
+++ b/pimotorcontrol.py
@@ -125,6 +125,57 @@ class MCP3008PositionSensor:
         self.spi.close()
 
 
+# -----------------------------------------------------------------------------
+# voltage_to_pct
+# -----------------------------------------------------------------------------
+# Module-level helper that converts a potentiometer voltage reading into a
+# percentage-open value given the configured fully-closed and fully-open
+# voltage thresholds.
+#
+# This is a standalone function rather than a pimc method for two reasons:
+#
+#   1. Callers that already have a fresh ADC reading cached (e.g. open_increment
+#      after a move completes) can pass it directly, avoiding a second ADC read
+#      that could return a slightly different value due to pot wiper noise.
+#      Consistent with the current_voltage caching pattern used elsewhere.
+#
+#   2. Scripts that use MCP3008PositionSensor directly without a pimc instance
+#      (e.g. greenhouse_metrics.py) can import and call this function with their
+#      own reading and configured thresholds, without needing a full pimc instance.
+#
+# The result is clamped to 0-100 to handle readings that drift slightly outside
+# the configured voltage range due to potentiometer wear or ADC noise.
+# -----------------------------------------------------------------------------
+
+def voltage_to_pct(voltage, voltage_fully_closed, voltage_fully_open):
+    """Convert a potentiometer voltage reading to a percentage-open value.
+
+    Calculates where the given voltage falls within the configured travel range
+    (voltage_fully_closed to voltage_fully_open) and returns it as a percentage.
+    Result is clamped to 0-100 to handle readings that drift slightly outside
+    the configured range due to potentiometer wear or ADC noise.
+
+    This function does not read the ADC — the caller is responsible for
+    providing a voltage reading. This allows callers that already have a cached
+    reading to reuse it, avoiding a second ADC read that could return a
+    slightly different value due to pot wiper noise.
+
+    Args:
+        voltage(float): The potentiometer voltage reading to convert, in volts.
+        voltage_fully_closed(float): The voltage corresponding to 0% open (fully closed).
+        voltage_fully_open(float): The voltage corresponding to 100% open (fully open).
+
+    Returns:
+        pct(float): Percentage open, clamped to 0.0-100.0.
+    """
+    travel = voltage_fully_open - voltage_fully_closed
+    if travel == 0:
+        # Avoid division by zero if misconfigured thresholds are identical.
+        return 0.0
+    pct = (voltage - voltage_fully_closed) / travel * 100.0
+    return max(0.0, min(100.0, pct))
+
+
 class pimc:
 
     # Valid relay_mode values.
@@ -219,7 +270,7 @@ class pimc:
             poll_interval_seconds(float): How long to sleep between ADC reads inside the
                                           run_until_voltage() loop. Controls both CPU usage and
                                           the responsiveness of position feedback. Defaults to
-                                          0.05s (50ms). For short moves (50-200ms total travel),
+                                          0.01s (10ms). For short moves (50-200ms total travel),
                                           smaller values give more position samples per move.
                                           Should be smaller than direction_settle_seconds so that
                                           at least one sample is taken during the settling period
@@ -584,7 +635,34 @@ class pimc:
         """
         return self.position_sensor.read()
 
-    def is_fully_open(self):
+    def read_position_pct(self):
+        """Read the current motor position as a percentage open.
+
+        Convenience method for callers that want a percentage and do not already
+        have a cached voltage reading. Calls read_position() once and passes the
+        result to voltage_to_pct().
+
+        Callers that already have a fresh voltage reading (e.g. after a move
+        completes) should call voltage_to_pct() directly with the cached value
+        rather than calling this method, to avoid a second ADC read that could
+        return a slightly different value due to pot wiper noise.
+
+        Requires position_sensor, voltage_fully_closed, and voltage_fully_open
+        to be configured at instantiation.
+
+        Args:
+            None
+
+        Returns:
+            pct(float): Current position as percentage open, clamped to 0.0-100.0.
+        """
+        return voltage_to_pct(
+            self.read_position(),
+            self.voltage_fully_closed,
+            self.voltage_fully_open
+        )
+
+    def is_fully_open(self, current_voltage=None):
         """Determine whether the motor is at or past the fully open position.
 
         Uses voltage_tolerance so that a motor that is physically stopped
@@ -592,27 +670,28 @@ class pimc:
         hard stops, or ADC noise) is still considered fully open.
 
         Args:
-            None
+            current_voltage(float): Optional voltage reading to re-use instead of sampling
 
         Returns:
             result(bool): True if current position is within tolerance of fully open
-                          or beyond it.
-        """
-        return self.read_position() >= (self.voltage_fully_open - self.voltage_tolerance)
+                          or beyond it. """
+        current_voltage = current_voltage if current_voltage is not None else self.read_position()
+        return current_voltage >= (self.voltage_fully_open - self.voltage_tolerance)
 
-    def is_fully_closed(self):
+    def is_fully_closed(self, current_voltage=None):
         """Determine whether the motor is at or past the fully closed position.
 
         Uses voltage_tolerance for the same reasons as is_fully_open().
 
         Args:
-            None
+            current_voltage(float): Optional voltage reading to re-use instead of sampling
 
         Returns:
             result(bool): True if current position is within tolerance of fully closed
                           or beyond it.
         """
-        return self.read_position() <= (self.voltage_fully_closed + self.voltage_tolerance)
+        current_voltage = current_voltage if current_voltage is not None else self.read_position()
+        return current_voltage <= (self.voltage_fully_closed + self.voltage_tolerance)
 
     def run_until_voltage(self, target_voltage, direction):
         """Run the motor until the ADC reads within tolerance of a target voltage.
@@ -769,7 +848,7 @@ class pimc:
         )
         return False
 
-    def open_increment(self):
+    def open_increment(self, check_limits=True):
         """Move the motor open by one voltage increment.
 
         Reads current position, computes a target voltage one increment higher,
@@ -783,12 +862,13 @@ class pimc:
         tolerance), no movement is attempted.
 
         Args:
-            None
+            check_limits(bool): Check whether the target is already fully open before calculating and executing a move; default True. Limits will still not be exceeded by a calculated move increment, but a proactive check will be skipped.
 
         Returns:
             success(bool): True if the increment was completed successfully.
                            False if already fully open, voltage_increment not set,
-                           or if a fault occurred.
+                           or if a fault occurred. None if no movement is needed 
+                           due to already being at limits (not a fault condition)
         """
         if self.voltage_increment is None:
             self.logger.error(
@@ -796,12 +876,14 @@ class pimc:
                 "Provide voltage_increment at construction time to use open_increment()."
             )
             return False
-
-        if self.is_fully_open():
-            self.logger.info("open_increment: already at fully open position, not moving")
-            return False
-
+        # cache this starting position to ensure consistency for checks and logging
+        # as fluttering marginal voltages could cause confusion during troubleshooting
         current_voltage = self.read_position()
+
+        if check_limits and self.is_fully_open(current_voltage):
+            self.logger.info("open_increment: already at or near enough fully open position (%.3fV), not moving", current_voltage)
+            return None
+
 
         # Compute target: one increment up, but no further than fully open.
         # This means the final increment may be smaller than voltage_increment
@@ -820,12 +902,27 @@ class pimc:
         result = self.run_until_voltage(target_voltage, direction='increasing')
         self.stop_and_housekeeping()
 
+        # Read final position once and reuse for both voltage and percentage
+        # logging, avoiding two ADC reads that could return differing values
+        # due to pot wiper noise.
+        final_voltage = self.read_position()
+        final_pct = voltage_to_pct(final_voltage, self.voltage_fully_closed, self.voltage_fully_open)
+
         if not result:
-            self.logger.error("open_increment: failed to reach target voltage")
+            self.logger.error(
+                "open_increment: failed to reach target voltage. "
+                "final=%.3fV (%.1f%% open) target=%.3fV",
+                final_voltage, final_pct, target_voltage
+            )
             self.update_status("failed opening", use_future=False)
+        else:
+            self.logger.info(
+                "open_increment: move complete. final=%.3fV (%.1f%% open)",
+                final_voltage, final_pct
+            )
         return result
 
-    def close_increment(self):
+    def close_increment(self, check_limits=True):
         """Move the motor closed by one voltage increment.
 
         Reads current position, computes a target voltage one increment lower,
@@ -839,7 +936,7 @@ class pimc:
         tolerance), no movement is attempted.
 
         Args:
-            None
+            check_limits(bool): Check whether the target is already fully closed before calculating and executing a move; default True.  Limits will still not be exceeded by a calculated move increment, but a proactive check will be skipped.
 
         Returns:
             success(bool): True if the increment was completed successfully.
@@ -853,11 +950,13 @@ class pimc:
             )
             return False
 
-        if self.is_fully_closed():
-            self.logger.info("close_increment: already at fully closed position, not moving")
-            return False
-
+        # cache this starting position to ensure consistency for checks and logging
+        # as fluttering marginal voltages could cause confusion during troubleshooting
         current_voltage = self.read_position()
+
+        if check_limits and self.is_fully_closed(current_voltage):
+            self.logger.info("close_increment: already at or near enough to fully closed position (%.3fV), not moving", current_voltage)
+            return None
 
         # Compute target: one increment down, but no lower than fully closed.
         # Same partial-increment logic as open_increment — move to fully closed
@@ -875,9 +974,24 @@ class pimc:
         result = self.run_until_voltage(target_voltage, direction='decreasing')
         self.stop_and_housekeeping()
 
+        # Read final position once and reuse for both voltage and percentage
+        # logging, avoiding two ADC reads that could return differing values
+        # due to pot wiper noise.
+        final_voltage = self.read_position()
+        final_pct = voltage_to_pct(final_voltage, self.voltage_fully_closed, self.voltage_fully_open)
+
         if not result:
-            self.logger.error("close_increment: failed to reach target voltage")
+            self.logger.error(
+                "close_increment: failed to reach target voltage. "
+                "final=%.3fV (%.1f%% open) target=%.3fV",
+                final_voltage, final_pct, target_voltage
+            )
             self.update_status("failed closing", use_future=False)
+        else:
+            self.logger.info(
+                "close_increment: move complete. final=%.3fV (%.1f%% open)",
+                final_voltage, final_pct
+            )
         return result
 
     def _require_position_sensor(self, action_name):

--- a/telemetry.py
+++ b/telemetry.py
@@ -115,8 +115,7 @@ class TelemetryClient:
         # Elasticsearch API key auth uses the 'ApiKey' scheme with the
         # key value as provided by Kibana (id:api_key format, base64-encoded).
         import base64
-        encoded = base64.b64encode(api_key.encode()).decode()
-        self.auth_header = f"ApiKey {encoded}"
+        self.auth_header = f"ApiKey {api_key}"
 
         # Import requests here so that the import error is clear if the
         # library is not installed, rather than surfacing at emit() time.

--- a/telemetry.py
+++ b/telemetry.py
@@ -1,0 +1,299 @@
+import logging
+import socket
+from datetime import datetime, timezone
+
+# -----------------------------------------------------------------------------
+# telemetry.py - Elasticsearch telemetry client for Raspberry Pi projects
+# -----------------------------------------------------------------------------
+#
+# This module provides a lightweight Elasticsearch telemetry client for
+# emitting metrics and events from Raspberry Pi projects to a central
+# Elasticsearch instance.
+#
+# INTENDED USAGE:
+#
+#   Instantiate TelemetryClient once at startup, passing the Elasticsearch
+#   host and API key. Call emit() to submit documents to any index.
+#
+#   from telemetry import TelemetryClient
+#   telemetry = TelemetryClient(api_key="your-api-key")
+#   telemetry.emit("pi-metrics", {"temperature_f": 82.4, "source": "greenhouse"})
+#
+# FAULT SAFETY:
+#
+#   Telemetry failures are logged but never raised to the caller. A failure
+#   to submit a document must never cause the calling code to fault — the
+#   physical control logic (motor movement, vent control) is always more
+#   important than the telemetry record of it. This is enforced by the
+#   try/except in emit().
+#
+# TIMESTAMPS:
+#
+#   The caller should pass a timestamp representing when the event or
+#   measurement actually occurred, not when emit() is called. This matters
+#   for retry/buffering scenarios and ensures that temperature readings
+#   align accurately with vent events on Kibana timelines.
+#
+#   If no timestamp is passed, emit() generates one at call time, which
+#   is acceptable for simple callers where submission latency is negligible.
+#
+# TLS:
+#
+#   Elasticsearch 8.x uses TLS by default. This client disables certificate
+#   verification (verify=False) because the default Elasticsearch install
+#   uses a self-signed certificate. This is acceptable for a private LAN
+#   deployment but should be revisited if the deployment is ever exposed
+#   beyond a trusted network. See the verify parameter on emit() for details.
+#
+# INDEX CONVENTIONS:
+#
+#   Two indices are used across all Pi projects:
+#     pi-metrics  — periodic numeric measurements (temperature, water level, etc.)
+#     pi-events   — electromechanical events (vent actions, pump start/stop, etc.)
+#
+#   Both indices use named fields. Common fields across all documents:
+#     @timestamp  — ISO 8601 UTC timestamp of when the event/measurement occurred
+#     host        — hostname of the Pi that generated the document
+#     source      — logical source name (e.g. 'greenhouse', 'sump')
+#
+#   pi-events additionally uses:
+#     level       — severity: 'info', 'warn', or 'error'
+#     event_type  — category of event (e.g. 'vent_action', 'pump_event')
+#     action      — specific action taken (e.g. 'opened_increment')
+#
+#   Field names should be consistent across documents of the same logical
+#   type to avoid Elasticsearch mapping conflicts. For example, temperature
+#   is always 'temperature_f' whether it appears in pi-metrics or pi-events.
+# -----------------------------------------------------------------------------
+
+
+class TelemetryClient:
+
+    # Default index names. Callers may pass any index name to emit(), but
+    # these are the conventional names for the two shared indices.
+    INDEX_METRICS = "pi-metrics"
+    INDEX_EVENTS = "pi-events"
+
+    def __init__(self, api_key, host="localhost", port=9200, source=None, logger=None):
+        """Initialize the TelemetryClient.
+
+        Args:
+            api_key(str): Elasticsearch API key for authentication. REQUIRED.
+                          Create via Kibana > Stack Management > API Keys.
+                          Format is 'id:api_key' as shown by Kibana after creation.
+                          No default — an absent or incorrect key will cause all
+                          emit() calls to fail with an authentication error, which
+                          is logged but not raised.
+            host(str): Elasticsearch host. Defaults to 'localhost'. For a remote
+                       Elasticsearch instance, pass the IP or hostname.
+            port(int): Elasticsearch port. Defaults to 9200.
+            source(str): Logical source name for this client instance, added to
+                         every document as the 'source' field. For example,
+                         'greenhouse' or 'sump'. If None, the 'source' field is
+                         not added automatically — the caller must include it in
+                         the document payload. Defaults to None.
+            logger(obj): Logger to use. Uses module logger if None.
+        """
+        if not api_key:
+            raise ValueError(
+                "api_key is required. Create one via Kibana > Stack Management > API Keys."
+            )
+
+        self.host = host
+        self.port = port
+        self.source = source
+        self.logger = logger or logging.getLogger(__name__)
+
+        # Determine the hostname of this Pi once at init time rather than on
+        # every emit() call. Used as the 'host' field in every document.
+        self.hostname = socket.gethostname()
+
+        # Build the base URL for the Elasticsearch REST API.
+        self.base_url = f"https://{host}:{port}"
+
+        # Build the Authorization header value from the API key.
+        # Elasticsearch API key auth uses the 'ApiKey' scheme with the
+        # key value as provided by Kibana (id:api_key format, base64-encoded).
+        import base64
+        encoded = base64.b64encode(api_key.encode()).decode()
+        self.auth_header = f"ApiKey {encoded}"
+
+        # Import requests here so that the import error is clear if the
+        # library is not installed, rather than surfacing at emit() time.
+        try:
+            import requests
+            self.requests = requests
+        except ImportError:
+            raise ImportError(
+                "The 'requests' library is required by TelemetryClient. "
+                "Install it with: pip install requests --break-system-packages"
+            )
+
+        self.logger.debug(
+            "TelemetryClient initialized. host=%s port=%s source=%s hostname=%s",
+            host, port, source, self.hostname
+        )
+
+    def _build_timestamp(self, timestamp=None):
+        """Return a timestamp string suitable for Elasticsearch's @timestamp field.
+
+        Args:
+            timestamp(str or datetime or None): If a string, returned as-is (assumed
+                to already be ISO 8601 UTC). If a datetime, converted to ISO 8601 UTC
+                string. If None, the current UTC time is used.
+
+        Returns:
+            timestamp_str(str): ISO 8601 UTC timestamp string.
+        """
+        if timestamp is None:
+            return datetime.now(timezone.utc).isoformat()
+        if isinstance(timestamp, datetime):
+            # Ensure timezone awareness. If a naive datetime is passed, assume UTC.
+            if timestamp.tzinfo is None:
+                self.logger.warning(
+                    "A naive datetime was passed to emit(). Assuming UTC. "
+                    "Pass timezone-aware datetimes to avoid ambiguity."
+                )
+                timestamp = timestamp.replace(tzinfo=timezone.utc)
+            return timestamp.isoformat()
+        # Assume string, return as-is.
+        return timestamp
+
+    def emit(self, index, document, timestamp=None):
+        """Submit a document to Elasticsearch.
+
+        Adds envelope fields (@timestamp, host, source) to the document and
+        POSTs it to the specified index via the Elasticsearch REST API.
+
+        Failures are logged but never raised. A telemetry failure must never
+        fault the calling code — physical control logic takes priority.
+
+        Args:
+            index(str): Elasticsearch index to submit the document to.
+                        Use TelemetryClient.INDEX_METRICS or INDEX_EVENTS for
+                        the standard shared indices, or any string for a custom index.
+            document(dict): Document payload. Should not include @timestamp, host,
+                            or source — these are added automatically by emit().
+                            If the caller includes them, they will be overwritten
+                            by the envelope values.
+            timestamp(str or datetime or None): Timestamp representing when the
+                            event or measurement occurred. Should be passed by
+                            callers that have a meaningful event time (e.g. the
+                            moment a temperature reading was taken). If None,
+                            the current UTC time at emit() call time is used.
+                            See module docstring for reasoning on caller-supplied
+                            timestamps.
+
+        Returns:
+            success(bool): True if the document was accepted by Elasticsearch,
+                           False if any error occurred. The caller may check this
+                           but is not required to — telemetry failures are
+                           non-fatal by design.
+        """
+        # Build the envelope. These fields are added to every document
+        # regardless of index or document type.
+        envelope = {
+            "@timestamp": self._build_timestamp(timestamp),
+            "host": self.hostname,
+        }
+
+        # Only add 'source' if this client was configured with one.
+        # Callers that manage multiple sources from one client can include
+        # 'source' in their document payload instead.
+        if self.source is not None:
+            envelope["source"] = self.source
+
+        # Merge envelope into document. Envelope fields take precedence —
+        # this prevents callers from accidentally overriding @timestamp or host
+        # with incorrect values.
+        payload = {**document, **envelope}
+
+        url = f"{self.base_url}/{index}/_doc"
+        headers = {
+            "Authorization": self.auth_header,
+            "Content-Type": "application/json",
+        }
+
+        try:
+            response = self.requests.post(
+                url,
+                json=payload,
+                headers=headers,
+                # TLS certificate verification is disabled because Elasticsearch's
+                # default install uses a self-signed certificate. This is acceptable
+                # for a private LAN deployment. If this client is ever used over an
+                # untrusted network, pass verify='/path/to/ca-cert.pem' instead.
+                verify=False,
+                timeout=5,
+            )
+
+            if response.status_code in (200, 201):
+                self.logger.debug(
+                    "emit: document accepted. index=%s id=%s",
+                    index, response.json().get("_id", "unknown")
+                )
+                return True
+            else:
+                self.logger.error(
+                    "emit: Elasticsearch rejected document. index=%s status=%s response=%s",
+                    index, response.status_code, response.text
+                )
+                return False
+
+        except self.requests.exceptions.Timeout:
+            self.logger.error(
+                "emit: timed out submitting to Elasticsearch. index=%s host=%s port=%s",
+                index, self.host, self.port
+            )
+            return False
+
+        except self.requests.exceptions.ConnectionError:
+            self.logger.error(
+                "emit: connection error submitting to Elasticsearch. index=%s host=%s port=%s. "
+                "Is Elasticsearch running and reachable?",
+                index, self.host, self.port
+            )
+            return False
+
+        except Exception as e:
+            # Catch-all to ensure telemetry failures never propagate to the caller.
+            # Log the full exception for diagnosis but return False gracefully.
+            self.logger.error(
+                "emit: unexpected error submitting to Elasticsearch. index=%s error=%s",
+                index, e
+            )
+            return False
+
+    def emit_metric(self, document, timestamp=None):
+        """Convenience wrapper for emit() targeting the pi-metrics index.
+
+        Args:
+            document(dict): Metric document payload. Named fields, e.g.
+                            {"temperature_f": 82.4} or
+                            {"water_level_cm": 14.2, "pressure_psi": 12.1}
+            timestamp(str or datetime or None): See emit().
+
+        Returns:
+            success(bool): See emit().
+        """
+        return self.emit(self.INDEX_METRICS, document, timestamp=timestamp)
+
+    def emit_event(self, document, timestamp=None):
+        """Convenience wrapper for emit() targeting the pi-events index.
+
+        Args:
+            document(dict): Event document payload. Should include at minimum
+                            'level', 'event_type', and 'action' fields. e.g.
+                            {
+                              "level": "info",
+                              "event_type": "vent_action",
+                              "action": "opened_increment",
+                              "temperature_f": 82.4,
+                              "position_voltage": 2.14
+                            }
+            timestamp(str or datetime or None): See emit().
+
+        Returns:
+            success(bool): See emit().
+        """
+        return self.emit(self.INDEX_EVENTS, document, timestamp=timestamp)


### PR DESCRIPTION
…ck via MCP3008 ADC, as well as an alternate relay mode of operation - 'enable_direction', such that one relay enables power and the second controls direction.  This is useful for a 3-wire 120v ac motor that uses two different hot lines for different coil arrangements to change direction.